### PR TITLE
Bump analyzer versions and add SECURITY.md

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,13 +45,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.7">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please follow these steps:
+
+1. **Do not** create a public issue on this repository.
+2. In the top navigation of this repository, click the **Security** tab.
+3. In the top right, click the **Report a vulnerability** button.
+4. Fill out the provided form with:
+   - A description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact
+   - Suggested fix (if you have one)
+
+## Response Timeline
+
+We will acknowledge your report within 48 hours and provide an estimated timeline for a fix.
+
+## Thank You
+
+Your help is greatly appreciated!
+Responsible disclosure of security vulnerabilities helps protect our entire community.


### PR DESCRIPTION
## Summary
- Bump Meziantou.Analyzer from 3.0.7 to 3.0.27
- Bump SonarAnalyzer.CSharp from 10.19.0.132793 to 10.21.0.135717
- Add SECURITY.md with GitHub Security tab reporting instructions

## Test plan
- [ ] Verify build passes with updated analyzers
- [ ] Verify SECURITY.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)