### PR TITLE
Replace noreply email with Security tab link in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -64,8 +64,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-.
+reported to the community leaders responsible for enforcement via the
+[Security tab](https://github.com/Chris-Wolfgang/repo-template/security) on this repository.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,7 +65,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement via the
-[Security tab](https://github.com/Chris-Wolfgang/repo-template/security) on this repository.
+[Security tab](../../security) on this repository.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Summary
- Replace the placeholder contact line in CODE_OF_CONDUCT.md with a link to the repository's Security tab
- The GitHub noreply address may not receive inbound mail, so reporters are now directed to a working channel

## Test plan
- [x] Verify the markdown link renders correctly in the PR diff
- [x] Confirm the Security tab URL resolves to the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)