### PR TITLE
Use Security tab for Code of Conduct enforcement reports

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -64,8 +64,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement via the
-[Security tab](../../security) on this repository.
+reported to the community leaders responsible for enforcement by
+[privately reporting through the repository's Security tab](../../security/advisories/new).
+Although this tab is labeled for security vulnerabilities, it provides
+a private channel suitable for sensitive reports including Code of Conduct violations.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Summary
- Updates CODE_OF_CONDUCT.md enforcement contact to use the repository's Security tab
- Replaces the plain link with the full advisory submission URL and explanatory text
- Matches the pattern applied across all other repos in this org

The Security tab provides a private channel suitable for sensitive CoC reports, which GitHub profiles do not guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)