### PR TITLE
Fix Setup-BranchRuleset.ps1 stage names to match pr.yaml v3

### DIFF
--- a/scripts/Setup-BranchRuleset.ps1
+++ b/scripts/Setup-BranchRuleset.ps1
@@ -190,9 +190,8 @@ $rulesetConfig = @{
                 # block the merge. All required status checks must run on every PR.
                 required_status_checks = @(
                     @{ context = "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate" },
-                    @{ context = "Stage 2a: Windows Tests (.NET 5.0-10.0)" },
-                    @{ context = "Stage 2b: macOS Tests (.NET 6.0-10.0)" },
-                    @{ context = "Stage 3: Windows .NET Framework Tests (4.6.2-4.8.1)" },
+                    @{ context = "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)" },
+                    @{ context = "Stage 3: macOS Tests (.NET 6.0-10.0)" },
                     @{ context = "Security Scan (DevSkim)" }
                 )
             }
@@ -242,9 +241,8 @@ try {
         }
         Write-Host "   ✅ Required status checks (must pass before merging):" -ForegroundColor Gray
         Write-Host "      - Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate" -ForegroundColor DarkGray
-        Write-Host "      - Stage 2a: Windows Tests (.NET 5.0-10.0)" -ForegroundColor DarkGray
-        Write-Host "      - Stage 2b: macOS Tests (.NET 6.0-10.0)" -ForegroundColor DarkGray
-        Write-Host "      - Stage 3: Windows .NET Framework Tests (4.6.2-4.8.1)" -ForegroundColor DarkGray
+        Write-Host "      - Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)" -ForegroundColor DarkGray
+        Write-Host "      - Stage 3: macOS Tests (.NET 6.0-10.0)" -ForegroundColor DarkGray
         Write-Host "      - Security Scan (DevSkim)" -ForegroundColor DarkGray
         Write-Host "   ✅ Branches must be up to date before merging" -ForegroundColor Gray
         Write-Host "   ✅ Conversation resolution required before merging" -ForegroundColor Gray


### PR DESCRIPTION
## Summary
The `Setup-BranchRuleset.ps1` required_status_checks used v2 stage names (`Stage 2a`, `Stage 2b`, `Stage 3: Windows .NET Framework`) but `pr.yaml` uses v3 names (`Stage 2: Windows Tests`, `Stage 3: macOS Tests`). This mismatch causes rulesets to require checks that never appear, blocking merges.

Changes:
- `Stage 2a: Windows Tests (.NET 5.0-10.0)` → `Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)`
- `Stage 2b: macOS Tests (.NET 6.0-10.0)` → `Stage 3: macOS Tests (.NET 6.0-10.0)`
- Removed `Stage 3: Windows .NET Framework Tests (4.6.2-4.8.1)` (merged into Stage 2 in v3)
- Updated success output messages to match

## Test plan
- [ ] Run `Setup-BranchRuleset.ps1` and verify required checks match pr.yaml job names

🤖 Generated with [Claude Code](https://claude.com/claude-code)