### PR TITLE
Gracefully skip test stages when ./tests directory is missing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -402,12 +402,20 @@ jobs:
 
       - name: Run tests with coverage (.NET Core 5.0 - 10.0)
         run: |
-          # Find all test projects (C#, VB.NET, F#)
+          # Find all test projects (C#, VB.NET, F#).
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          # The downstream coverage steps already handle the no-coverage-files case.
+          if [ ! -d ./tests ]; then
+            echo "ℹ️  No ./tests directory — skipping test stage."
+            exit 0
+          fi
+
           mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
-          
+
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "❌ No test projects found in ./tests directory!"
-            exit 1
+            echo "ℹ️  No test projects found under ./tests — skipping test stage."
+            exit 0
           fi
           
           echo "=========================================="
@@ -674,12 +682,19 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          
+
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          if (-not (Test-Path -Path './tests' -PathType Container)) {
+            Write-Host "ℹ️  No ./tests directory — skipping test stage."
+            exit 0
+          }
+
           $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
-          
+
           if (@($testProjects).Count -eq 0) {
-            Write-Error "❌ No test projects found in ./tests directory!"
-            exit 1
+            Write-Host "ℹ️  No test projects found under ./tests — skipping test stage."
+            exit 0
           }
           
           Write-Host "==========================================" -ForegroundColor Cyan
@@ -1035,15 +1050,22 @@ jobs:
 
       - name:  Run tests (.NET 6.0 - 10.0 only - ARM64 compatible)
         run: |
-          # Find all test projects (C#, VB.NET, F#)
+          # Find all test projects (C#, VB.NET, F#).
+          # Gracefully skip if there is no ./tests directory (e.g. template-publishing
+          # repos or library repos in early development that have no tests yet).
+          if [ ! -d ./tests ]; then
+            echo "ℹ️  No ./tests directory — skipping test stage."
+            exit 0
+          fi
+
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)          
-          
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "❌ No test projects found in ./tests directory!"
-            exit 1
+            echo "ℹ️  No test projects found under ./tests — skipping test stage."
+            exit 0
           fi
           
           echo "=========================================="


### PR DESCRIPTION
## Summary

Stages 1 (Linux), 2 (Windows), and 3 (macOS) hard-fail with \`❌ No test projects found in ./tests directory!\` when \`./tests\` doesn't exist. This blocks any PR — including Dependabot bumps unrelated to tests — in two legitimate cases:

1. **Template-publishing repos** (e.g. \`console-app-template\`) that ship templates under \`src/\` and have no tests of their own
2. **Library repos in early development** that have not added tests yet (e.g. several of the empty placeholder repos)

## Fix

At each of the three test discovery sites, check for \`./tests\` up front. If it doesn't exist (or contains no test projects), log an informational message and \`exit 0\` instead of \`exit 1\`. Each of:

- Stage 1 Linux test step (bash) — line ~404
- Stage 2 Windows test step (pwsh) — line ~676
- Stage 3 macOS test step (bash) — line ~1040

The downstream coverage steps already gracefully handle the no-coverage-files case via the \`has-coverage\` output (\`if: steps.check-coverage.outputs.has-coverage == 'true'\`), so no further changes are required.

## Why this is the right fix vs. per-repo branch ruleset overrides

- **Single source of truth** — one ruleset shape across all 19+ repos; no need to maintain a separate \`Setup-BranchRuleset.ps1\` config for template/empty repos
- **Green checks, not bypassed reds** — test stages report success with a \"no tests, skipping\" message. Maintainers don't have to mentally filter out expected failures, which preserves CI signal value
- **Future-proofing** — any new repo without tests yet works out of the box

This mirrors the existing graceful-skip pattern used by the CodeQL workflow when there is no C# code to scan.

## Test plan

- [ ] Sync this \`pr.yaml\` into \`console-app-template\` and verify \`#134\` (Meziantou.Analyzer bump) passes Stage 1 with the new skip message
- [ ] Verify a normal library repo with a real \`./tests\` directory still runs tests as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)