### PR TITLE
Fix typo in .gitignore Claude Code section header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.userosscache
 *.sln.docstates
 *.env
-n# Claude Code
+# Claude Code
 .claude/
 
 # User-specific files (MonoDevelop/Xamarin Studio)


### PR DESCRIPTION
## Summary

The header line for the Claude Code section in \`.gitignore\` had a stray \`n\` prefix:

\`\`\`gitignore
n# Claude Code
.claude/
\`\`\`

The \`n\` makes the line no longer a recognized comment header (it's now a pattern that would match a literal file named \`n# Claude Code\` if one existed — harmless but wrong). Strip the \`n\` so the header is a clean \`# Claude Code\`.

## How this was found

Spotted while diffing \`Log-Compressor\`'s \`.gitignore\` against the template — the downstream repo had already cleaned up the typo locally, but the template still has it, so any new repo created from the template inherits the typo.

## Test plan

- [ ] Verify \`.gitignore\` parses cleanly (it already did — this is purely cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)