### PR TITLE
Exempt Dependabot from protected configuration file guard

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,6 +77,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -120,6 +124,11 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
       
       - name: Detect protected configuration file changes
+        # Skip for Dependabot — its bumps to protected files (e.g. Directory.Build.props)
+        # are legitimate. The guard's threat model is human PR authors disabling analyzers
+        # in their own PRs; it does not apply to a trusted GitHub-controlled bot whose
+        # only action is package-version updates.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Checking for changes to protected configuration files in this PR..."
           
@@ -201,6 +210,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -244,6 +257,10 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 
@@ -861,6 +878,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -904,6 +925,10 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 
@@ -1231,6 +1256,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -1274,6 +1303,10 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 


### PR DESCRIPTION
## Summary

Skips the protected-files guard in \`pr.yaml\` for Dependabot PRs so weekly analyzer-package bumps land cleanly without manual intervention.

## Problem

The guard exists to prevent untrusted PR authors from disabling analyzers in their own PR to make CI pass. It works as two steps in every job in pr.yaml:

1. **\`Fetch trusted configuration files from main branch\`** — copies main's versions over the PR's, so even if a PR modifies \`Directory.Build.props\` the build runs against main's contents
2. **\`Detect protected configuration file changes\`** — fails CI if any protected file was modified

That threat model is **human PR authors weakening security**. It does **not** apply to Dependabot:
- Dependabot is a GitHub-controlled trusted bot
- Its identity (\`dependabot[bot]\`) is not spoofable from a PR
- Its only action is package-version updates

But the guard still trips on Dependabot's bumps to analyzer \`<PackageReference>\` items in \`Directory.Build.props\`, requiring the maintainer to **disable branch protection, merge, and re-enable it weekly** for every analyzer-bump PR.

## Fix

Add \`if: github.event.pull_request.user.login != 'dependabot[bot]'\` to both steps. Human PRs continue to be validated identically.

## Why this is safe

- \`pull_request_target\` exposes \`github.event.pull_request.user.login\` from the GitHub event payload, which is set by GitHub itself, not by the PR's git contents. A malicious PR cannot spoof this value.
- If GitHub itself were compromised, much worse things would already be possible — the guard isn't the right defense layer for that scenario anyway.
- The fix only loosens the guard for one specific bot login; everyone else (including any user-created PRs) is still subject to the full guard.

## Test plan

- [ ] Verify a manually-opened PR that modifies \`Directory.Build.props\` still fails the guard
- [ ] Verify the next Dependabot analyzer bump merges cleanly without intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)