### PR TITLE
Discover solution file explicitly in Stage 2 (Windows)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -690,10 +690,38 @@ jobs:
             10.0.x
 
       - name: Restore dependencies
-        run: dotnet restore
+        # Discover the solution file explicitly rather than relying on dotnet's
+        # implicit cwd resolution. This fixes:
+        #   - MSB1003 ("Specify a project or solution file") in repos whose
+        #     solution lives in a subfolder (e.g. console-app-template's
+        #     src/ConsoleAppTemplate.sln) — bare 'dotnet restore' fails because
+        #     the repo root has no solution.
+        #   - MSB1011 ("Specify which project or solution file to use") in
+        #     repos with multiple solution files at root.
+        # Preference order: .slnx (newer XML-based format) → .sln. Among multiple
+        # candidates of the same extension, pick the alphabetically-first.
+        shell: bash
+        run: |
+          sln=$(git ls-files '*.slnx' | head -1)
+          [ -z "$sln" ] && sln=$(git ls-files '*.sln' | head -1)
+          if [ -n "$sln" ]; then
+            echo "Discovered solution: $sln"
+            dotnet restore "$sln"
+          else
+            echo "ℹ️  No solution file found — falling back to bare 'dotnet restore'."
+            dotnet restore
+          fi
 
       - name: Build solution
-        run: dotnet build --no-restore --configuration Release
+        shell: bash
+        run: |
+          sln=$(git ls-files '*.slnx' | head -1)
+          [ -z "$sln" ] && sln=$(git ls-files '*.sln' | head -1)
+          if [ -n "$sln" ]; then
+            dotnet build "$sln" --no-restore --configuration Release
+          else
+            dotnet build --no-restore --configuration Release
+          fi
 
       - name: Run all .NET tests (.NET 5.0-10.0 and Framework 4.6.2-4.8.1)
         shell: pwsh


### PR DESCRIPTION
## Summary

Replaces bare `dotnet restore` / `dotnet build --no-restore` in Stage 2 with explicit solution discovery via `git ls-files`. Fixes failures across two related symptoms.

## Problem

Stage 2's restore/build steps run from the repo root with no solution argument. `dotnet` then has to guess what to build, which fails in two real scenarios:

| Symptom | Affected repo example | Reason |
|---|---|---|
| `MSB1003: Specify a project or solution file` | [`console-app-template`](https://github.com/Chris-Wolfgang/console-app-template/pull/137) | Solution lives in a subfolder (`src/ConsoleAppTemplate.sln`); repo root has nothing |
| `MSB1011: Specify which project or solution file to use` | [`IEquatable-Extensions`](https://github.com/Chris-Wolfgang/IEquatable-Extensions/pull/61) | Two solution files at root (`IEquatable Extensions.slnx` + `Solution.slnx`) |

## Fix

Discover the solution file before running `dotnet`:

```bash
sln=$(git ls-files '*.slnx' | head -1)
[ -z "$sln" ] && sln=$(git ls-files '*.sln' | head -1)
if [ -n "$sln" ]; then
  dotnet restore "$sln"
else
  echo "ℹ️  No solution file found — falling back to bare 'dotnet restore'."
  dotnet restore
fi
```

Preference order:
- `.slnx` (newer XML-based format) before `.sln`
- Among multiple candidates of the same extension: alphabetically-first via `head -1` (git emits in sorted order, so this naturally prefers root-level over nested when extensions match)
- Fall back to bare `dotnet restore` only if no solution exists at all (the build still has to fail loudly in that case — there is no sensible default)

Same logic in both `Restore dependencies` and `Build solution` steps.

`shell: bash` is set explicitly because Windows runners default to `pwsh`, but bash quoting around space-containing solution names (e.g. `IEquatable Extensions.slnx`) is more reliable.

## Subsumes

[`IEquatable-Extensions` #61](https://github.com/Chris-Wolfgang/IEquatable-Extensions/pull/61) — the per-repo fix for `MSB1011`. Once this template change propagates, that PR can be closed.

## Test plan

- [ ] Verify Stage 2 passes on a normal repo with a single root-level `.slnx`
- [ ] Verify Stage 2 passes on `console-app-template` (nested solution)
- [ ] Verify Stage 2 passes on `IEquatable-Extensions` (multiple solutions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)