### PR TITLE
Upgrade release workflow actions to Node 24

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -525,7 +525,7 @@ jobs:
             10.0.x
 
       - name: Download packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: nuget-packages
           path: ./packages
@@ -597,13 +597,13 @@ jobs:
       contents: write  # Required to upload assets to the GitHub Release
     steps:
       - name: Download NuGet packages artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages
 
       - name: Download coverage report artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: release-coverage
           path: ./release-coverage
@@ -612,7 +612,7 @@ jobs:
         run: zip -r release-coverage.zip ./release-coverage
 
       - name: Attach artifacts to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -300,6 +301,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -517,6 +519,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x


### PR DESCRIPTION
## Summary
- `actions/download-artifact`: v4 → v8.0.1
- `softprops/action-gh-release`: v2.5.0 (SHA `a06a81a0`) → v3.0.0 (SHA `b4309332`)

Mirrors the change validated in [ETL-Test-Kit#54](https://github.com/Chris-Wolfgang/ETL-Test-Kit/pull/54). Clears the Node.js 20 deprecation warning that was emitted on release runs.

## Breaking change review
- `download-artifact` v5 changed the output path for single artifact downloads by ID. This workflow only downloads by `name:`, so unaffected. v6/v7/v8 are runtime + ESM + hash-mismatch-becomes-error changes, none breaking for our usage.
- `action-gh-release` v3.0.0 is purely a Node 24 runtime bump per release notes.

## Test plan
- [ ] Same change merged and validated in ETL-Test-Kit