### PR TITLE
Require CodeQL and gitleaks status checks on main

### DIFF
--- a/scripts/Setup-BranchRuleset.ps1
+++ b/scripts/Setup-BranchRuleset.ps1
@@ -192,13 +192,17 @@ $rulesetConfig = @{
                     @{ context = "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate" },
                     @{ context = "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)" },
                     @{ context = "Stage 3: macOS Tests (.NET 6.0-10.0)" },
-                    @{ context = "Security Scan (DevSkim)" }
+                    @{ context = "Security Scan (DevSkim)" },
+                    @{ context = "Security Scan (CodeQL) (csharp)" },
+                    @{ context = "Secrets Scan (gitleaks)" }
                 )
             }
         },
-        # NOTE: code_scanning (CodeQL) is not included in this API-created ruleset because
-        # it requires a CodeQL workflow to be present and have run on the repo. Without prior
-        # analyses, the rule blocks all PRs. Add CodeQL integration separately if needed.
+        # NOTE: the code_scanning *rule type* (which checks the CodeQL alerts dashboard) is not
+        # included because it requires a CodeQL workflow to have run previously on the repo;
+        # without prior analyses it blocks all PRs. The CodeQL job IS required above as a
+        # status check ("Security Scan (CodeQL) (csharp)"), which only requires that the
+        # CodeQL build/analysis succeed on each PR.
         # NOTE: Copilot code review is not included in this API-created payload because
         # it is not currently supported through the rulesets API. After the ruleset is
         # created, enable Copilot code review settings manually in the GitHub repository UI.
@@ -244,6 +248,8 @@ try {
         Write-Host "      - Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)" -ForegroundColor DarkGray
         Write-Host "      - Stage 3: macOS Tests (.NET 6.0-10.0)" -ForegroundColor DarkGray
         Write-Host "      - Security Scan (DevSkim)" -ForegroundColor DarkGray
+        Write-Host "      - Security Scan (CodeQL) (csharp)" -ForegroundColor DarkGray
+        Write-Host "      - Secrets Scan (gitleaks)" -ForegroundColor DarkGray
         Write-Host "   ✅ Branches must be up to date before merging" -ForegroundColor Gray
         Write-Host "   ✅ Conversation resolution required before merging" -ForegroundColor Gray
         Write-Host "   ✅ Stale reviews dismissed when new commits are pushed" -ForegroundColor Gray


### PR DESCRIPTION
## Summary
Adds two existing-but-unrequired status checks to the `required_status_checks` list created by `Setup-BranchRuleset.ps1`:

- `Security Scan (CodeQL) (csharp)`
- `Secrets Scan (gitleaks)`

Both jobs already run on every PR; this just makes them block merges if they fail.

## Why
On [ETL-Json#51](https://github.com/Chris-Wolfgang/ETL-Json/pull/51) a `NU1605` package downgrade error caused the CodeQL build to fail. Stage 1 Linux Tests (a required check) also failed and would have blocked the merge — but if those tests had restored differently and only CodeQL had caught it, the PR would have been technically mergeable since CodeQL wasn't required.

## Note on the existing comment
The block comment about excluding `code_scanning` is preserved. That's the *rule type* (which inspects the CodeQL alerts dashboard and requires prior analyses to exist). The new entry is a `required_status_checks` context — just requires the CodeQL job to succeed on the PR. No chicken-and-egg problem.

## Existing repos
This script applies on new repo setup. The 20 existing repos that have a `Protect main branch` ruleset will keep their current 4 required checks until they're patched. That can be done by either:
- Running `Fix-BranchRuleset.ps1` then `Setup-BranchRuleset.ps1` (with the updated script) in each repo, or
- Patching the rulesets directly via API in a single batch

## Test plan
- [ ] Visual review of generated ruleset on next new repo setup