### PR TITLE
Add .github/workflows/* to protected file detection

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -95,6 +95,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -156,11 +158,11 @@ jobs:
             fi
           done
           
-          # Check .globalconfig and .ruleset files using the same git diff approach
+          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
           # --diff-filter=AMRC: Added, Modified, Renamed, Copied (excludes Deleted)
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '\.(globalconfig|ruleset)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
@@ -228,6 +230,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -275,6 +279,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
 
           # Copy each configuration file from main branch if it exists
@@ -615,8 +621,8 @@ jobs:
             }
           }
           
-          # Handle glob patterns for .globalconfig and .ruleset files
-          $globPatterns = @("*.globalconfig", "*.ruleset")
+          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -660,8 +666,8 @@ jobs:
             }
           }
 
-          # Handle glob patterns for .globalconfig and .ruleset files
-          $globPatterns = @("*.globalconfig", "*.ruleset")
+          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -896,6 +902,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -943,6 +951,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
 
           # Copy each configuration file from main branch if it exists
@@ -1274,6 +1284,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -1321,6 +1333,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
 
           # Copy each configuration file from main branch if it exists


### PR DESCRIPTION
## Why

Mirrors [Chris-Wolfgang/Try-Pattern#88](https://github.com/Chris-Wolfgang/Try-Pattern/pull/88) into the template so:

1. New repos created from this template inherit workflow-file protection from day one
2. Existing repos doing a "sync from template" pass pick it up
3. Try-Pattern's customization stays consistent with the template

## What

The "Detect protected configuration file changes" step already fails PRs that modify \`.editorconfig\`, \`Directory.Build.props/.targets\`, \`BannedSymbols.txt\`, \`*.globalconfig\`, or \`*.ruleset\`. This extends the same protection to \`.github/workflows/*.yml\`/\`*.yaml\`.

## Why it matters

\`pull_request_target\` sources the workflow from main, so a malicious PR modifying \`pr.yaml\` on its branch can't take effect. But:

- A subtly broken workflow YAML (e.g. duplicate mapping key) can silently disable CI without any error. **We hit this exact failure mode in Try-Pattern this month** — a duplicate \`run:\` key blocked CI for ~2 weeks of merges before being tracked down.
- If the trigger is ever flipped back to \`pull_request\`, workflow files would suddenly run from PR branches with no signal that they changed.

Failing loudly on workflow modifications gives maintainers a clear "review carefully" signal regardless of the trigger model.

## Changes

- **7 bash \`Fetch trusted configuration files\` steps**: added \`.github/workflows/*.yml\` and \`.github/workflows/*.yaml\` to \`config_files=()\`
- **2 PowerShell \`Fetch trusted configuration files\` steps**: added the same patterns to \`\$globPatterns\`
- **1 \`Detect protected configuration file changes\` step**: extended grep regex to match \`^\.github/workflows/.*\.ya?ml\$\`

## Verification

- YAML parses cleanly: \`name='PR Checks v3 (Gated)'\`, trigger=\`pull_request_target\`, 6 jobs
- Net diff: +20 lines, -6 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)