### PR TITLE
Validate release tag matches csproj version before pack/publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,60 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate release tag matches csproj version
+        shell: pwsh
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          # Strip leading 'v' or 'v.' from the tag (v0.3.0 -> 0.3.0, v.0.1.0 -> 0.1.0)
+          $tagName = $env:RELEASE_TAG_NAME
+          $tagVersion = $tagName -replace '^v\.?', ''
+          Write-Host "Release tag:      $tagName" -ForegroundColor Cyan
+          Write-Host "Expected version: $tagVersion" -ForegroundColor Cyan
+          Write-Host ""
+
+          $srcCsprojs = @(Get-ChildItem -Path './src' -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
+          if ($srcCsprojs.Count -eq 0) {
+            Write-Warning "No src csprojs found - skipping version validation"
+            exit 0
+          }
+
+          # Collect <Version> and <PackageVersion> values from every src csproj
+          $found = @()
+          foreach ($proj in $srcCsprojs) {
+            try {
+              [xml]$xml = Get-Content $proj.FullName -Raw
+              $nodes = $xml.SelectNodes('//Version | //PackageVersion')
+              foreach ($node in $nodes) {
+                $v = $node.InnerText.Trim()
+                if ($v) {
+                  $found += [pscustomobject]@{ Project = $proj.Name; Version = $v }
+                }
+              }
+            } catch {
+              Write-Warning "Failed to parse $($proj.Name): $($_.Exception.Message)"
+            }
+          }
+
+          Write-Host "Versions found in src csprojs:" -ForegroundColor Cyan
+          foreach ($f in $found) {
+            Write-Host "  $($f.Project): $($f.Version)" -ForegroundColor DarkGray
+          }
+          Write-Host ""
+
+          if ($found.Count -eq 0) {
+            Write-Error "No <Version> or <PackageVersion> found in any src csproj"
+            exit 1
+          }
+
+          if ($found.Version -contains $tagVersion) {
+            Write-Host "Release tag matches at least one src csproj version" -ForegroundColor Green
+          } else {
+            $allVersions = ($found.Version | Sort-Object -Unique) -join ', '
+            Write-Error "Release tag '$tagName' (version '$tagVersion') does not match any src csproj version. Found: $allVersions. Bump the csproj <Version> or correct the release tag before re-running."
+            exit 1
+          }
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Summary
Adds an early step in the `validate-release` job that fails the release if the GitHub release tag does not match any src csproj's `<Version>` (or `<PackageVersion>`).

## The bug this prevents
Workflow could silently succeed without publishing anything new:

1. Cut a `vX.Y.Z` GitHub release.
2. csproj `<Version>` is still on the **previous** version.
3. `dotnet pack` produces a nupkg at the previous version.
4. `dotnet nuget push` returns `409 Conflict` (already exists).
5. `--skip-duplicate` swallows the error → workflow reports success.
6. NuGet shows no new version.

This exact scenario hit Try-Pattern's `v0.3.0` release.

## What this PR does
Inserts a validation step between **Checkout** and **Setup .NET** in the `validate-release` job:

- Reads the release tag (`${{ github.event.release.tag_name }}`)
- Strips a leading `v` or `v.` (e.g. `v0.3.0` → `0.3.0`, `v.0.1.0` → `0.1.0`)
- Recursively scans `src/**/*.csproj` for `<Version>` and `<PackageVersion>` elements
- Fails with a clear message if no csproj version matches the tag

## Multi-project repos
Passes if **any** src csproj version matches the tag. ETL-Test-Kit (TestKit + TestKit.Xunit) and console-app-template (3 templates) can release sub-packages on their own cadence — only one needs to match the tag for the release to be valid.

## Rollout
After merge, the same change can be propagated to the 21 dependent repos that share this workflow (same kind of batch update used for the Node 24 / 3.1 fixes).

## Test plan
- [ ] Manually trigger by cutting a tag/release whose version doesn't match the csproj — confirm the job fails with a clear error
- [ ] Confirm the validate step is skipped on `repo-template` itself (`if: github.repository != 'Chris-Wolfgang/repo-template'` is already on the job)