### PR TITLE
Require 'Detect .NET Projects' status check on main

### DIFF
--- a/scripts/Setup-BranchRuleset.ps1
+++ b/scripts/Setup-BranchRuleset.ps1
@@ -189,6 +189,7 @@ $rulesetConfig = @{
                 # and doesn't run for a PR, GitHub will treat the required check as missing and
                 # block the merge. All required status checks must run on every PR.
                 required_status_checks = @(
+                    @{ context = "Detect .NET Projects" },
                     @{ context = "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate" },
                     @{ context = "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)" },
                     @{ context = "Stage 3: macOS Tests (.NET 6.0-10.0)" },
@@ -244,6 +245,7 @@ try {
             Write-Host "   ✅ No approvals required (single-developer mode)" -ForegroundColor Gray
         }
         Write-Host "   ✅ Required status checks (must pass before merging):" -ForegroundColor Gray
+        Write-Host "      - Detect .NET Projects" -ForegroundColor DarkGray
         Write-Host "      - Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate" -ForegroundColor DarkGray
         Write-Host "      - Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)" -ForegroundColor DarkGray
         Write-Host "      - Stage 3: macOS Tests (.NET 6.0-10.0)" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary
Adds `Detect .NET Projects` to the `required_status_checks` list in `Setup-BranchRuleset.ps1`. New repos set up via this script will require the check to pass before any PR can merge to `main`.

## Why
The `detect-projects` job in `pr.yaml` hosts the **protected-files guard** (`Detect protected configuration file changes`). The guard's purpose is to fail any PR that modifies workflow / `Directory.Build.props` / `.editorconfig` / `*.globalconfig` / `*.ruleset` files, forcing a maintainer to manually review the change.

But the guard was **decorative** in most repos: when it failed, the PR's `mergeStateStatus` was just `UNSTABLE` (warning) rather than `BLOCKED`. The "Merge" button stayed enabled and you could click through. Only `IEnumerable-Extensions` had `Detect .NET Projects` in its required list — that's the one repo where the guard actually blocked.

This change makes the guard enforce its policy everywhere.

## Existing repos
The 22 affected repos (all 21 .NET libraries + Hawsey + Log-Compressor) were patched via API call (matching the same pattern as the earlier CodeQL/gitleaks ruleset patch). This template change just keeps future setups in sync.

## Test plan
- [ ] On the next new repo created from the template, run `Setup-BranchRuleset.ps1` and confirm `Detect .NET Projects` appears in the required checks list