### PR TITLE
Harden gitleaks step: SHA256-pin binary + protect .gitleaks.toml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,12 +50,26 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Fetch trusted gitleaks config from main
+        # Prevent PR from modifying .gitleaks.toml to bypass the scan
+        run: |
+          git fetch origin main --depth=1
+          git checkout origin/main -- .gitleaks.toml 2>/dev/null || true
+        shell: bash
+
       - name: Run gitleaks
         # gitleaks-action@v2 does not support pull_request_target, so invoke the CLI directly
+        # Pinned to a specific version with SHA256 checksum verification for supply-chain safety
         run: |
           GITLEAKS_VERSION="8.24.0"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar xz -C /usr/local/bin gitleaks
+          GITLEAKS_SHA256="cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4"
+          mkdir -p "$HOME/.local/bin"
+          TARBALL="$(mktemp)"
+          curl -sSfL -o "$TARBALL" "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  ${TARBALL}" | sha256sum -c - || { echo "Checksum verification failed!"; exit 1; }
+          tar xzf "$TARBALL" -C "$HOME/.local/bin" gitleaks
+          rm -f "$TARBALL"
+          export PATH="$HOME/.local/bin:$PATH"
           gitleaks detect --source . --verbose --redact
         shell: bash
 


### PR DESCRIPTION
## Summary
Adopts two security improvements from `ICollection-Extensions`'s `pr.yaml`:

1. **New step: `Fetch trusted gitleaks config from main`** — pulls `.gitleaks.toml` from the base branch before the scan runs, so a PR can't modify its own config to allowlist a leaked secret.

2. **SHA256-verified gitleaks binary download** — instead of `curl ... | tar xz`, the new flow downloads the tarball to a tempfile, verifies it against a pinned SHA256 with `sha256sum -c`, then extracts. Fails fast on hash mismatch. Mitigates supply-chain attacks against the GitHub release artifact.

Pinned version `8.24.0` with hash `cb49b7de...d75751f3a4`, matching the established pattern in `ICollection-Extensions/.github/workflows/pr.yaml`.

## Why
The current gitleaks step:
- Pipes `curl` directly into `tar` with no integrity check — anyone who compromises GitHub's download infrastructure could substitute a malicious gitleaks binary
- Uses the PR's `.gitleaks.toml` if a PR happens to modify it, which would allow an attacker to allowlist their own secret

ICollection-Extensions has had the hardened version for a while; this PR brings it into the canonical template so the rest of the repos can pick it up via the upcoming pr.yaml drift sync.

## Test plan
- [ ] Workflow CI on this PR runs the new gitleaks step successfully
- [ ] Downstream `pr.yaml` drift sync (planned) propagates this to the 22 dependent repos