### PR TITLE
Adopt coverlet.runsettings for code coverage

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -481,6 +481,7 @@ jobs:
                 --configuration Release \
                 --framework "$fw" \
                 --collect:"XPlat Code Coverage" \
+                --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=minimal" || exit 1
             done <<< "$frameworks"
@@ -766,6 +767,7 @@ jobs:
                   --configuration Release `
                   --framework $fw `
                   --collect:"XPlat Code Coverage" `
+                  --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=normal"
               } else {
@@ -1144,6 +1146,7 @@ jobs:
                 --configuration Release \
                 --framework "$fw" \
                 --collect:"XPlat Code Coverage" \
+                --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=normal" || exit 1
             done <<< "$frameworks"

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByFile>**/bin/**/*.cs;**/obj/**/*.cs</ExcludeByFile>
+          <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary
Adds `coverlet.runsettings` to the canonical template and wires `--settings coverlet.runsettings` into the three `dotnet test` invocations in `pr.yaml` that collect coverage (Stage 1 Linux, Stage 2 Windows, Stage 3 macOS).

```xml
<?xml version="1.0" encoding="utf-8"?>
<RunSettings>
  <DataCollectionRunSettings>
    <DataCollectors>
      <DataCollector friendlyName="XPlat Code Coverage">
        <Configuration>
          <Format>cobertura</Format>
          <ExcludeByFile>**/bin/**/*.cs;**/obj/**/*.cs</ExcludeByFile>
          <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
        </Configuration>
      </DataCollector>
    </DataCollectors>
  </DataCollectionRunSettings>
</RunSettings>
```

## Why
Without this configuration, coverlet uses defaults — it does **not** honor the `[ExcludeFromCodeCoverage]` attribute. CLAUDE.md already mandates that attribute on test POCOs and compiler-generated code. So this configuration brings the coverage tooling in line with the documented convention.

The `<ExcludeByFile>` rule is a belt-and-suspenders guard against generated `bin/` and `obj/` artifacts.

## Existing usage
7 of 18 dependent repos already had this pattern (with minor drift between their `coverlet.runsettings` files):

- ETL-Test-Kit
- ETL-Json
- ETL-DbClient
- IAsyncEnumerable-Extensions
- ICollection-Extensions
- Try-Pattern
- DbContextBuilder

This PR consolidates a single canonical version they can all sync to via the planned `pr.yaml` drift sync.

## Test plan
- [ ] Workflow runs on this PR (no functional impact since repo-template has no tests, the dotnet test commands won't execute)
- [ ] After merge + downstream sync: confirm coverage reports correctly exclude `[ExcludeFromCodeCoverage]`-marked code