### PR TITLE
.editorconfig: relax analyzers in tests, benchmarks, and examples

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -387,9 +387,11 @@ dotnet_diagnostic.MA0051.severity = none         # Method length OK in tests
 # SonarAnalyzer - Relax in tests
 dotnet_diagnostic.S1118.severity = none          # Utility class constructors OK in tests
 dotnet_diagnostic.S1135.severity = none          # TODO tags OK in tests
+dotnet_diagnostic.S1144.severity = none          # Unused private members OK in tests (reflection-based POCOs)
 dotnet_diagnostic.S3216.severity = none          # ConfigureAwait not needed in tests
 dotnet_diagnostic.S3776.severity = none          # Complexity OK in tests
 dotnet_diagnostic.S4049.severity = none          # Properties vs methods flexibility in tests
+dotnet_diagnostic.S6966.severity = none          # Async versions not available on all target frameworks
 
 # .NET Analyzer - Relax in tests
 dotnet_diagnostic.CA2007.severity = none         # ConfigureAwait not needed in tests
@@ -425,6 +427,24 @@ dotnet_diagnostic.SA1600.severity = none
 dotnet_diagnostic.SA1601.severity = none
 dotnet_diagnostic.SA1602.severity = none
 
+# Suppress Meziantou, Sonar, and VSTHRD analyzers in benchmarks
+dotnet_diagnostic.MA0002.severity = none
+dotnet_diagnostic.MA0011.severity = none
+dotnet_diagnostic.MA0016.severity = none
+dotnet_diagnostic.MA0021.severity = none
+dotnet_diagnostic.MA0036.severity = none
+dotnet_diagnostic.MA0038.severity = none
+dotnet_diagnostic.MA0040.severity = none
+dotnet_diagnostic.MA0048.severity = none
+dotnet_diagnostic.MA0051.severity = none
+dotnet_diagnostic.MA0053.severity = none
+dotnet_diagnostic.MA0076.severity = none
+dotnet_diagnostic.S1118.severity = none
+dotnet_diagnostic.S1144.severity = none
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S6966.severity = none
+dotnet_diagnostic.VSTHRD200.severity = none
+
 # Example projects - relaxed naming, docs encouraged
 [examples/**/*.cs]
 # Allow Example_Method_Names
@@ -439,3 +459,24 @@ dotnet_diagnostic.SA1602.severity = suggestion
 
 # Banned API Analyzer - Allow in examples for demonstration purposes
 dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in examples for demonstration
+
+# Suppress Meziantou, Sonar, and VSTHRD analyzers in examples
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.MA0002.severity = none
+dotnet_diagnostic.MA0004.severity = none
+dotnet_diagnostic.MA0011.severity = none
+dotnet_diagnostic.MA0016.severity = none
+dotnet_diagnostic.MA0021.severity = none
+dotnet_diagnostic.MA0036.severity = none
+dotnet_diagnostic.MA0038.severity = none
+dotnet_diagnostic.MA0040.severity = none
+dotnet_diagnostic.MA0048.severity = none
+dotnet_diagnostic.MA0051.severity = none
+dotnet_diagnostic.MA0053.severity = none
+dotnet_diagnostic.MA0076.severity = none
+dotnet_diagnostic.S1118.severity = none
+dotnet_diagnostic.S1144.severity = none
+dotnet_diagnostic.S3216.severity = none
+dotnet_diagnostic.S3776.severity = none
+dotnet_diagnostic.S6966.severity = none
+dotnet_diagnostic.VSTHRD200.severity = none


### PR DESCRIPTION
## Summary
Adopts ETL-DbClient's additional analyzer suppressions for non-source code:

**`[tests/**/*.cs]`** — adds 2 SonarAnalyzer rules:
- `S1144` (Unused private members) — relevant for repos using reflection (TestKit, JSON, XML, DbClient all populate test fields via reflection)
- `S6966` (Async versions vary across TFMs) — relevant for any multi-TFM repo

**`[benchmarks/**/*.cs]`** — adds 16 Meziantou/Sonar/VSTHRD suppressions. Benchmarks are timing-sensitive code that intentionally violates analyzer expectations (small repetitive methods, no cancellation token flow, etc.).

**`[examples/**/*.cs]`** — adds 19 Meziantou/Sonar/VSTHRD/CA2007 suppressions. Examples prioritize clarity over analyzer compliance — they're learning material, not production code.

## Source
All additions adopted from `ETL-DbClient/.editorconfig`. After this lands, ETL-DbClient's local versions become redundant; its `.editorconfig` can sync to canonical without losing functionality.

## Why broadly applicable
Every repo on this template has `tests/`, `benchmarks/`, and `examples/` directories. The analyzer relaxations are generic patterns: reflection-driven testing, timing-sensitive benchmark code, and clarity-prioritized examples. Useful everywhere.

## Test plan
- [ ] After merge + sync to dependent repos, no spurious analyzer warnings on benchmark/example code
- [ ] Test code using reflection-populated fields no longer triggers S1144