### PR TITLE
Bump centralized analyzers: Meziantou 3.0.58, Sonar 10.25.0.139117

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,13 +45,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Bumps `Meziantou.Analyzer` 3.0.27 → 3.0.58
- Bumps `SonarAnalyzer.CSharp` 10.21.0.135717 → 10.25.0.139117

## Why
Dependabot has already pushed these (or newer) versions into several downstream repos (e.g. IComparable-Extensions). With canonical lagging, the in-flight bulk Directory.Build.props centralization rollout would *appear* as a downgrade for any repo Dependabot has already serviced. Bumping canonical to current NuGet latest keeps the template actually canonical: new repos start on current versions, and the rollout shows clean diffs.

The other four analyzers (Roslynator 4.15.0, AsyncFixer 2.1.0, VS.Threading 17.14.15, BannedApiAnalyzers 4.14.0) are already at NuGet's current latest.

## Test plan
- [ ] CI green on this PR (Detect .NET Projects has no projects in repo-template, so primarily checks pass)
- [ ] After merge, downstream rollout uses these versions in `Directory.Build.props` syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)