### PR TITLE
Relax RS0030 from warning to none in tests and benchmarks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -376,8 +376,8 @@ dotnet_diagnostic.VSTHRD107.severity = none       # Allow Task in using without 
 dotnet_diagnostic.VSTHRD114.severity = none       # Allow returning null from Task methods in tests
 dotnet_diagnostic.VSTHRD200.severity = none       # Async suffix not required in test method names
 
-# Banned API Analyzer - Just warn in tests (allow for testing purposes)
-dotnet_diagnostic.RS0030.severity = warning       # Using banned API - warn instead of error in tests
+# Banned API Analyzer - Allow in tests (sync I/O and Stream overrides are common in test setup)
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in tests
 
 # Meziantou - Relax in tests
 dotnet_diagnostic.MA0004.severity = none         # ConfigureAwait not needed in tests
@@ -422,8 +422,8 @@ dotnet_diagnostic.MA0004.severity = none          # Meziantou: Use ConfigureAwai
 dotnet_diagnostic.S3216.severity = none           # SonarAnalyzer: ConfigureAwait
 dotnet_diagnostic.CA2007.severity = none          # .NET Analyzer: Use ConfigureAwait
 
-# Banned API Analyzer - Just warn in benchmarks (allow for benchmarking purposes)
-dotnet_diagnostic.RS0030.severity = warning       # Using banned API - warn instead of error in benchmarks
+# Banned API Analyzer - Allow in benchmarks (sync APIs are often the benchmark target)
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in benchmarks
 
 # No documentation required for benchmarks
 dotnet_diagnostic.SA1600.severity = none


### PR DESCRIPTION
## Summary
Changes \`dotnet_diagnostic.RS0030.severity\` from \`warning\` to \`none\` in the \`[tests/**/*.cs]\` and \`[benchmarks/**/*.cs]\` sections of \`.editorconfig\`.

## Why
The prior \`severity = warning\` was meant to "warn but allow" the banned API analyzer in test/benchmark code, but Release builds enable \`TreatWarningsAsErrors=true\` which promotes the warning back to error — defeating the relaxation entirely.

Setting severity to \`none\` matches the existing pattern for every other relaxed rule in those folders (AsyncFixer01/02/05, VSTHRD102/103/104/107/200, MA0004/0011/0026/0040/0048/0051, S1118/1135/1144/3216/3776/4049/6966, CA1849/2007), and matches the existing \`RS0030 = none\` in \`[examples/**/*.cs]\`.

## What this unblocks
- Sync setup I/O (\`File.WriteAllText\`, \`File.WriteAllBytes\`) in test fixtures
- Stream subclass overrides that must delegate to sync \`inner.Read\` / \`inner.Flush\` because the parent class methods are sync
- Sync code paths intentionally exercised by benchmarks (where \`async\` would distort the measurement)

Surfaced by [System.Mail-Extensions#60](https://github.com/Chris-Wolfgang/System.Mail-Extensions/pull/60) after the centralized analyzer rollout pushed RS0030 enforcement to test code that was previously unaffected.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, sync \`.editorconfig\` to System.Mail-Extensions and other repos with similar test patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)