### PR TITLE
Drop DocFX TargetFramework property from docfx.json

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -11,9 +11,6 @@
         }
       ],
       "dest": "api",
-      "properties": {
-        "TargetFramework": "net8.0"
-      },
       "disableGitFeatures": false,
       "disableDefaultFilter": false
     }


### PR DESCRIPTION
## Summary
The template ships `docfx_project/docfx.json` with `properties.TargetFramework: net8.0`, which seeds a release-time bug into every downstream repo whose source project doesn't target net8.0. Per CLAUDE.md, new repos use `net462;netstandard2.0;netstandard2.1;net10.0` (no net8.0); when those repos cut their first release, DocFX errors with `CS0234: namespace 'Extensions' does not exist in 'Microsoft'` and `CS0246: 'ILogger' could not be found` because MSBuild restores against a TFM the project doesn't declare.

## Fix
Remove the `properties.TargetFramework` block entirely so DocFX picks the highest available TFM automatically. This matches what sister repos with no `TargetFramework` property already do (DbContextBuilder, In-Memory Logger, IEnumerable-Extensions, IEquatable-Extensions, Roll-For-It, sandals-search, etc.).

## Repos discovered with the same bug
- **Extensions-Logging-Data** (v0.1.0 docs job failed — fix PR open: `Chris-Wolfgang/Extensions-Logging-Data#20`)
- **Hawsey** (currently affected — separate PR forthcoming)
- **Log-Compressor** (empty src/ — would trip on first source addition without net8.0; preemptive fix PR forthcoming)

## Test plan
- [ ] CI green on this PR (docfx.json change only)
- [ ] Downstream repos that pick this template change see clean DocFX builds without having to manage `TargetFramework` themselves

🤖 Generated with [Claude Code](https://claude.com/claude-code)