### PR TITLE
.gitignore: broaden DocFX _site rule to any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -427,7 +427,7 @@ CoverageReport/
 package-smoke-test/
 nuget-packages/
 
-# DocFX generated files
-docfx_project/_site/
+# DocFX generated files (any depth)
+_site/
 docfx_project/obj/
 


### PR DESCRIPTION
## Summary
Broadens the DocFX \`_site\` rule from \`docfx_project/_site/\` to just \`_site/\` so it matches any depth/path.

## Why
Some downstream repos (e.g. IEquatable-Extensions) showed untracked files under \`docfx_project/_site/api/\`, \`docfx_project/_site/docs/\`, etc. because the docfx layout differed slightly from the canonical path. The previous rule only matched the exact \`docfx_project/_site/\` path; the broader \`_site/\` catches any nested generated docfx output folder.

## Test plan
- [ ] CI green
- [ ] After merge, sync .gitignore to downstream repos with stale generated _site/ artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)