### PR TITLE
workflows: add 'dotnet workload restore' step before build

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -87,6 +87,26 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
+    - name: Restore .NET workloads
+      if: steps.check-csharp.outputs.has-csharp == 'true'
+      shell: pwsh
+      run: |
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads
+        # via their TFMs (e.g. net10.0-android). Install whatever the solution needs
+        # before restore. For pure libraries this is a fast no-op.
+        $solution = Get-ChildItem -Path . -Recurse -Depth 2 -Include "*.sln", "*.slnx" | Select-Object -First 1
+        if ($solution) {
+          Write-Host "Restoring workloads for $($solution.FullName)"
+          dotnet workload restore $solution.FullName
+        } else {
+          Write-Host "No solution found; restoring workloads for all projects"
+          dotnet workload restore
+        }
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "dotnet workload restore failed with exit code $LASTEXITCODE"
+          exit $LASTEXITCODE
+        }
+
     - name: Build for CodeQL Analysis
       id: build
       if: steps.check-csharp.outputs.has-csharp == 'true'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -344,6 +344,12 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure libraries it's a fast no-op.
+        run: dotnet workload restore
+
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
           echo "Finding .NET project files in repository (via find command)..."
@@ -710,6 +716,12 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure libraries it's a fast no-op.
+        run: dotnet workload restore
+
       - name: Restore dependencies
         run: dotnet restore
 
@@ -1006,6 +1018,12 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure libraries it's a fast no-op.
+        run: dotnet workload restore
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |


### PR DESCRIPTION
## Summary
Adds a `dotnet workload restore` step after each `setup-dotnet`, before any restore/build steps:

- **pr.yaml** (3 stages: Linux, Windows, macOS) — bare `dotnet workload restore`
- **codeql.yaml** (single C# job) — solution-aware pwsh version that finds the `.sln`/`.slnx` and restores against it

## Why
Projects that declare platform workloads via their TFMs (e.g. `net10.0-android`, `net10.0-windows10.0.19041.0`, `net10.0-ios`) fail to restore without `dotnet workload restore` first. MAUI / MauiHybrid / Android / iOS / WPF repos all hit this.

Discovered in Hawsey (which uses MAUI). Backporting to canonical so future workload-bearing repos work out of the box without each one having to re-discover the fix.

For pure library repos (no workload TFMs), `dotnet workload restore` is a fast no-op — typically <1s — so the cost is negligible.

## Test plan
- [ ] CI green on this PR (canonical itself has no workloads, so `dotnet workload restore` should be a no-op)
- [ ] After merge, propagate to downstream repos so the canonical sync stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)