### PR TITLE
Commit 4 template docs + add docs/* gitignore exception block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -431,3 +431,14 @@ nuget-packages/
 _site/
 docfx_project/obj/
 
+# Reference documentation under docs/ — keep tracked files visible, ignore everything else
+# (e.g., CI/CD-generated artifacts that some repos publish into docs/).
+docs/*
+!docs/.gitkeep
+!docs/LICENSE-SELECTION.md
+!docs/README-FORMATTING.md
+!docs/RELEASE-WORKFLOW-SETUP.md
+!docs/SECURITY.md
+!docs/TEMPLATE-PLACEHOLDERS.md
+!docs/WORKFLOW_SECURITY.md
+

--- a/docs/LICENSE-SELECTION.md
+++ b/docs/LICENSE-SELECTION.md
@@ -1,0 +1,403 @@
+# License Selection Guide
+
+Choosing the right license for your project is important. This guide helps you select between the three popular open-source licenses included in this template.
+
+---
+
+## Quick Decision Guide
+
+### Choose **MIT License** if:
+- ✅ You want maximum freedom for users
+- ✅ You want minimal restrictions
+- ✅ You don't need patent protection
+- ✅ You're building a library or utility
+- ✅ You want the simplest possible license
+
+### Choose **Apache License 2.0** if:
+- ✅ You want permissive licensing with patent protection
+- ✅ You're building enterprise software
+- ✅ You want users to credit changes
+- ✅ You need explicit patent grant
+- ✅ You want protection from patent trolls
+
+### Choose **Mozilla Public License 2.0** if:
+- ✅ You want file-level copyleft
+- ✅ You want modified files to remain open source
+- ✅ You want to allow proprietary combinations
+- ✅ You want weaker copyleft than GPL
+- ✅ You're building a library that may be used in commercial products
+
+---
+
+## Detailed Comparison
+
+### Permission Summary
+
+| Feature | MIT | Apache 2.0 | MPL 2.0 |
+|---------|-----|------------|---------|
+| **Commercial Use** | ✅ Yes | ✅ Yes | ✅ Yes |
+| **Modification** | ✅ Yes | ✅ Yes | ✅ Yes |
+| **Distribution** | ✅ Yes | ✅ Yes | ✅ Yes |
+| **Private Use** | ✅ Yes | ✅ Yes | ✅ Yes |
+| **Patent Grant** | ❌ No | ✅ Yes | ✅ Yes (limited) |
+| **Sublicensing** | ✅ Yes | ✅ Yes | ⚠️ Limited |
+| **Copyleft** | ❌ None | ❌ None | ⚠️ File-level |
+| **License Compatibility** | ✅ High | ✅ High | ⚠️ Medium |
+
+### Requirement Summary
+
+| Requirement | MIT | Apache 2.0 | MPL 2.0 |
+|------------|-----|------------|---------|
+| **Include License** | ✅ Required | ✅ Required | ✅ Required |
+| **Include Copyright** | ✅ Required | ✅ Required | ✅ Required |
+| **State Changes** | ❌ No | ✅ Required | ✅ Required |
+| **Disclose Source** | ❌ No | ❌ No | ⚠️ Modified files only |
+| **Same License** | ❌ No | ❌ No | ⚠️ Modified files only |
+| **Trademark Use** | ❌ Not granted | ❌ Not granted | ❌ Not granted |
+| **Liability** | ❌ None | ❌ None | ❌ None |
+| **Warranty** | ❌ None | ❌ None | ❌ None |
+
+---
+
+## License Details
+
+### 1. MIT License
+
+**Summary:** The most permissive and simple license. Anyone can do almost anything with your code.
+
+**Length:** ~170 words (very short)
+
+**Pros:**
+- ✅ Very simple and easy to understand
+- ✅ Maximum freedom for users
+- ✅ Widely recognized and trusted
+- ✅ Compatible with almost all other licenses
+- ✅ No "copyleft" requirements
+- ✅ Can be sublicensed under different terms
+- ✅ Business-friendly
+
+**Cons:**
+- ❌ No patent grant (potential patent issues)
+- ❌ No protection from patent trolls
+- ❌ Doesn't require attribution in binaries
+- ❌ No requirement to state changes
+- ❌ Code can be taken private
+
+**Best For:**
+- Libraries and frameworks
+- Utilities and tools
+- Educational projects
+- Projects where you want maximum adoption
+
+**Popular Projects Using MIT:**
+- jQuery
+- Rails
+- .NET Core
+- Node.js
+- React
+
+**Key Requirements:**
+1. Include original copyright notice
+2. Include license text
+
+**That's it!** Very minimal requirements.
+
+---
+
+### 2. Apache License 2.0
+
+**Summary:** Permissive license with explicit patent grant and requirement to state changes.
+
+**Length:** ~8,800 words (comprehensive)
+
+**Pros:**
+- ✅ Explicit patent grant protects users
+- ✅ Includes patent retaliation clause
+- ✅ Requires stating changes to code
+- ✅ Well-understood by corporations
+- ✅ Compatible with GPL 3.0
+- ✅ Trusted for enterprise use
+- ✅ Can be sublicensed
+
+**Cons:**
+- ❌ Longer and more complex than MIT
+- ❌ Requires NOTICE file for attributions
+- ❌ Requires stating changes
+- ❌ More paperwork for contributors
+- ❌ Incompatible with GPL 2.0
+
+**Best For:**
+- Enterprise software
+- Projects where patents are a concern
+- Large projects with many contributors
+- Projects needing patent protection
+
+**Popular Projects Using Apache 2.0:**
+- Android
+- Apache projects (Kafka, Spark, etc.)
+- Kubernetes
+- TensorFlow
+- Swift
+
+**Key Requirements:**
+1. Include original copyright notice
+2. Include license text
+3. State significant changes made
+4. Include NOTICE file if present
+5. Don't use trademarks without permission
+
+---
+
+### 3. Mozilla Public License 2.0 (MPL 2.0)
+
+**Summary:** Weak copyleft license - modified files must remain open, but can be combined with proprietary code.
+
+**Length:** ~4,700 words (medium)
+
+**Pros:**
+- ✅ File-level copyleft (weaker than GPL)
+- ✅ Can be combined with proprietary code
+- ✅ Includes patent grant
+- ✅ Compatible with GPL and LGPL
+- ✅ Requires sharing modifications
+- ✅ Business-friendly copyleft option
+
+**Cons:**
+- ❌ More complex than MIT/Apache
+- ❌ Modified files must stay open source
+- ❌ Requires separate file organization
+- ❌ Less common than MIT/Apache
+- ❌ Can complicate commercial use
+
+**Best For:**
+- Libraries used in commercial products
+- Projects wanting some copyleft protection
+- Mozilla-style projects
+- When you want modifications shared but allow proprietary combinations
+
+**Popular Projects Using MPL 2.0:**
+- Firefox
+- Thunderbird
+- LibreOffice
+- This template repository
+
+**Key Requirements:**
+1. Include original license notice
+2. Keep modified MPL files under MPL
+3. Disclose source of modified MPL files
+4. Can combine with proprietary code in separate files
+5. State changes to MPL files
+
+**File-Level Copyleft Explained:**
+- ✅ Can add proprietary files to project
+- ✅ Can link with proprietary libraries
+- ⚠️ Modified MPL files must remain MPL
+- ⚠️ Must share source of modified MPL files
+
+---
+
+## Decision Tree
+
+```
+Start Here
+│
+├─ Do you want modified code to remain open source?
+│  ├─ Yes → **Consider MPL 2.0**
+│  │  └─ But only for modified files? → **MPL 2.0**
+│  └─ No → Continue...
+│
+├─ Is patent protection important?
+│  ├─ Very important → **Apache 2.0**
+│  │  └─ Enterprise software? → **Apache 2.0**
+│  └─ Not critical → Continue...
+│
+├─ Do you want the simplest possible license?
+│  ├─ Yes → **MIT**
+│  │  └─ Maximum freedom? → **MIT**
+│  └─ No → **Apache 2.0** (safer than MIT)
+│
+└─ When in doubt → **MIT** (most popular)
+```
+
+---
+
+## Real-World Examples
+
+### Scenario 1: JavaScript Library
+**Project:** React-style UI framework
+
+**Recommendation:** **MIT**
+
+**Why:**
+- Maximum adoption in ecosystem
+- Compatible with all build tools
+- No patent concerns in JS ecosystem
+- Simple for contributors
+
+---
+
+### Scenario 2: Enterprise API Server
+**Project:** REST API server for financial data
+
+**Recommendation:** **Apache 2.0**
+
+**Why:**
+- Patent protection for API methods
+- Corporate-friendly
+- Protects against patent trolls
+- Clear change tracking
+
+---
+
+### Scenario 3: .NET Class Library
+**Project:** Extension methods library
+
+**Recommendation:** **MIT** or **Apache 2.0**
+
+**Why:**
+- **MIT:** If you want maximum adoption
+- **Apache 2.0:** If you have novel algorithms needing patent protection
+
+---
+
+### Scenario 4: Desktop Application
+**Project:** Open-source code editor
+
+**Recommendation:** **MPL 2.0**
+
+**Why:**
+- Ensures improvements stay open
+- Allows proprietary plugins
+- File-level copyleft is reasonable
+- Similar to VS Code approach (though VS Code uses MIT)
+
+---
+
+## License Compatibility
+
+### Can you combine licenses in one project?
+
+**MIT + Apache 2.0:** ✅ Yes  
+**MIT + MPL 2.0:** ✅ Yes  
+**Apache 2.0 + MPL 2.0:** ✅ Yes  
+**GPL 2.0 + Apache 2.0:** ❌ No (incompatible)  
+**GPL 3.0 + Apache 2.0:** ✅ Yes
+
+### Using libraries with different licenses:
+
+| Your License | Can use MIT libs? | Can use Apache 2.0 libs? | Can use MPL 2.0 libs? |
+|--------------|-------------------|--------------------------|----------------------|
+| **MIT** | ✅ Yes | ✅ Yes | ✅ Yes |
+| **Apache 2.0** | ✅ Yes | ✅ Yes | ✅ Yes |
+| **MPL 2.0** | ✅ Yes | ✅ Yes | ✅ Yes |
+
+**Note:** You can use more permissive libraries in less permissive projects, but not vice versa.
+
+---
+
+## Setup Instructions
+
+### Using the Automated Setup Script
+
+The setup scripts will prompt you to choose a license:
+
+```powershell
+pwsh ./scripts/setup.ps1
+```
+
+You'll be asked:
+```
+Select a license:
+1) MIT
+2) Apache-2.0
+3) MPL-2.0
+```
+
+The script will:
+1. Copy the chosen license template
+2. Replace `{{YEAR}}` with the current year
+3. Replace `{{COPYRIGHT_HOLDER}}` with your name
+4. Save as `LICENSE` (no extension)
+5. Delete all `LICENSE-*.txt` files
+
+### Manual Setup
+
+1. Choose a license from above
+2. Copy the corresponding file:
+   - `LICENSE-MIT.txt` → `LICENSE`
+   - `LICENSE-APACHE-2.0.txt` → `LICENSE`
+   - `LICENSE-MPL-2.0.txt` → `LICENSE`
+3. Replace placeholders:
+   - `{{YEAR}}` → Current year (e.g., `2024`)
+   - `{{COPYRIGHT_HOLDER}}` → Your name (e.g., `Chris Wolfgang`)
+4. Update `README.md`:
+   - Replace `{{LICENSE_TYPE}}` with `MIT`, `Apache-2.0`, or `MPL-2.0`
+5. Delete unused `LICENSE-*.txt` files
+
+---
+
+## Frequently Asked Questions
+
+### Q: Can I change the license later?
+
+**A:** Yes, but:
+- Previous versions remain under the old license
+- Requires all contributors to agree if not sole copyright holder
+- May complicate things for existing users
+
+### Q: What if I want dual licensing?
+
+**A:** This template supports single license only. For dual licensing:
+1. Keep both LICENSE files
+2. Add explanation in README
+3. Specify in headers which applies
+
+### Q: What about the Unlicense or CC0?
+
+**A:** These are public domain dedications, not licenses. Not included in this template as they're not recommended for software.
+
+### Q: What about GPL?
+
+**A:** GPL is not included because:
+- Strong copyleft can limit adoption
+- Not ideal for libraries
+- More complex for contributors
+- This template targets permissive licenses
+
+If you need GPL, use GPL templates specifically.
+
+---
+
+## Additional Resources
+
+### Official License Texts
+- **MIT:** https://opensource.org/licenses/MIT
+- **Apache 2.0:** https://www.apache.org/licenses/LICENSE-2.0
+- **MPL 2.0:** https://www.mozilla.org/en-US/MPL/2.0/
+
+### License Choosers
+- **GitHub:** https://choosealicense.com/
+- **OSI:** https://opensource.org/licenses/
+
+### Legal Resources
+- **SPDX License List:** https://spdx.org/licenses/
+- **TLDRLegal:** https://www.tldrlegal.com/
+
+**Disclaimer:** This guide is for informational purposes only and does not constitute legal advice. Consult a lawyer for specific legal questions.
+
+---
+
+## Quick Reference
+
+| Aspect | MIT | Apache 2.0 | MPL 2.0 |
+|--------|-----|------------|---------|
+| **Complexity** | ⭐ Simple | ⭐⭐⭐ Complex | ⭐⭐ Medium |
+| **Length** | ⭐ Short | ⭐⭐⭐ Long | ⭐⭐ Medium |
+| **Permissive** | ⭐⭐⭐ Very | ⭐⭐⭐ Very | ⭐⭐ Moderate |
+| **Patent Protection** | ❌ None | ⭐⭐⭐ Strong | ⭐⭐ Moderate |
+| **Business Friendly** | ⭐⭐⭐ Very | ⭐⭐⭐ Very | ⭐⭐ Moderate |
+| **Popularity** | ⭐⭐⭐ Very high | ⭐⭐⭐ High | ⭐⭐ Medium |
+
+---
+
+**Still unsure?** Choose **MIT** - it's the most popular and simplest option. You can always change it later (with caveats).

--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -1,0 +1,68 @@
+# Code Formatting
+
+This repository uses `dotnet format` to enforce consistent C# code style.
+
+## Prerequisites
+
+The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 and later. Since this project requires .NET 8.0 SDK or later, you already have `dotnet format` available — no separate tool installation is needed.
+
+> **Note:** The standalone `dotnet-format` global tool was deprecated when `dotnet format` was integrated into the .NET 6 SDK in August 2021.
+
+## For Developers
+
+### Before Committing
+
+Run the formatting script with PowerShell Core (`pwsh`) on any supported platform:
+
+```powershell
+.\format.ps1
+```
+
+Or check without making changes:
+
+```powershell
+.\format.ps1 -Check
+```
+
+### Manual Formatting
+
+```bash
+dotnet format
+```
+
+### Check Formatting (like CI does)
+
+```bash
+dotnet format --verify-no-changes
+```
+
+## Configuration
+
+Code style rules are defined in `.editorconfig` at the repository root.
+
+## CI/CD
+
+All pull requests are automatically checked for proper formatting. PRs with formatting issues will fail the build.
+
+### If CI Fails
+
+1. Run `.\format.ps1` locally
+2. Review the changes
+3. Commit and push the formatted code
+
+## IDE Integration
+
+Most IDEs automatically read `.editorconfig`:
+
+- **Visual Studio**: Built-in support, formats on save (Tools → Options → Text Editor → C# → Code Style)
+- **VS Code**: Install "EditorConfig for VS Code" extension
+- **JetBrains Rider**: Built-in support
+
+## Formatting Rules
+
+Key style rules:
+- **Indentation**: 4 spaces for C# (with `switch` case contents not additionally indented when inside a block, per `.editorconfig`), 2 for XML/JSON
+- **Braces**: Opening brace on new line
+- **Line endings**: LF (Unix style)
+- **Trailing whitespace**: Removed
+- **Using directives**: System namespaces first, sorted alphabetically

--- a/docs/TEMPLATE-PLACEHOLDERS.md
+++ b/docs/TEMPLATE-PLACEHOLDERS.md
@@ -1,0 +1,421 @@
+# Template Placeholders Documentation
+
+This document provides comprehensive documentation of all placeholders used in this repository template and instructions for replacing them.
+
+## Overview
+
+The automated setup script (`pwsh ./scripts/setup.ps1`) handles all placeholder replacements automatically. This document is for reference or manual setup if needed.
+
+---
+
+## Placeholder Format
+
+All placeholders use the format: `{{PLACEHOLDER_NAME}}`
+
+**Example:** `{{PROJECT_NAME}}` becomes `Wolfgang.Extensions.IAsyncEnumerable`
+
+---
+
+## Core Placeholders
+
+These placeholders are **required** and must be replaced in every project:
+
+| Placeholder | Description | Example Value | Auto-detected? |
+|------------|-------------|---------------|----------------|
+| `{{PROJECT_NAME}}` | Full project/library name | `Wolfgang.Extensions.IAsyncEnumerable` | No |
+| `{{PROJECT_DESCRIPTION}}` | One-line project description | `High-performance extension methods for IAsyncEnumerable<T>` | No |
+| `{{PACKAGE_NAME}}` | NuGet package name | `Wolfgang.Extensions.IAsyncEnumerable` | No (usually same as PROJECT_NAME) |
+| `{{GITHUB_REPO_URL}}` | Full GitHub repository URL | `https://github.com/Chris-Wolfgang/MyProject` | Yes (from `git remote`) |
+| `{{REPO_NAME}}` | Repository name only | `MyProject` | Yes (extracted from URL) |
+| `{{GITHUB_USERNAME}}` | GitHub username with @ | `@Chris-Wolfgang` | Yes (from GitHub repo URL, or prompted if missing) |
+| `{{DOCS_URL}}` | Documentation URL | `https://chris-wolfgang.github.io/MyProject/` | Yes (generated from repo URL) |
+| `{{LICENSE_TYPE}}` | License identifier | `MIT`, `Apache-2.0`, or `MPL-2.0` | No |
+| `{{YEAR}}` | Copyright year | `2024` | Yes (current year) |
+| `{{COPYRIGHT_HOLDER}}` | Copyright owner name | `Chris Wolfgang` | Yes (from `git config`) |
+| `{{NUGET_STATUS}}` | NuGet availability message | `Coming soon to NuGet.org` or `Available on NuGet.org` | No |
+| `{{TEMPLATE_REPO_OWNER}}` | Template repository owner (used in setup docs) | `Chris-Wolfgang` | No (prompted during setup) |
+| `{{TEMPLATE_REPO_NAME}}` | Template repository name (used in setup docs) | `repo-template` | No (prompted during setup) |
+
+---
+
+## Optional Content Placeholders
+
+These placeholders represent sections that users should fill in later. They can remain as placeholders initially:
+
+| Placeholder | Purpose | Location |
+|------------|---------|----------|
+| `{{QUICK_START_EXAMPLE}}` | Code example showing basic usage | README.md |
+| `{{FEATURES_TABLE}}` | Markdown table listing features | README.md |
+| `{{FEATURE_EXAMPLES}}` | Code examples demonstrating features | README.md |
+| `{{TARGET_FRAMEWORKS}}` | List of supported .NET frameworks | README.md |
+| `{{ACKNOWLEDGMENTS}}` | Credits for libraries/tools used | README.md |
+
+**Note:** The automated setup scripts do NOT replace these - users fill them in as they develop their project.
+
+---
+
+## Template Identification Placeholders
+
+### Purpose of TEMPLATE_REPO_OWNER and TEMPLATE_REPO_NAME
+
+The `{{TEMPLATE_REPO_OWNER}}` and `{{TEMPLATE_REPO_NAME}}` placeholders identify the original template repository used to create a new project. These values are primarily used in setup documentation to ensure that instructions accurately reference the actual template source.
+
+### Why This Matters
+
+When users:
+1. Fork the template to customize it
+2. Create their own variant of this template
+3. Use a customized version within an organization
+
+The setup instructions should reference the **actual template they used**, not the original upstream template. This prevents confusion during onboarding and documentation.
+
+### Default Values
+
+- **TEMPLATE_REPO_OWNER**: `Chris-Wolfgang` (the original template owner)
+- **TEMPLATE_REPO_NAME**: `repo-template` (the original template name)
+
+These defaults work for most users creating repositories directly from the original template.
+
+### When to Use Custom Values
+
+Users should provide custom values when:
+- Using a forked version of the template
+- Using an organization-specific template variant
+- The template has been renamed or moved to a different owner
+- Creating documentation for a derivative template
+
+### How These Values Are Collected
+
+The setup script (`pwsh ./scripts/setup.ps1`) prompts users for this information:
+
+**PowerShell (setup.ps1):**
+```powershell
+$templateRepoOwner = Read-Input `
+    -Prompt "Template Repository Owner" `
+    -Default "Chris-Wolfgang" `
+    -Example "YourUsername"
+
+$templateRepoName = Read-Input `
+    -Prompt "Template Repository Name" `
+    -Default "repo-template" `
+    -Example "my-template"
+```
+
+These values are collected during the interactive setup process (lines 341-349 in setup.ps1) and added to the replacements hashtable (lines 390-391).
+
+### Where These Are Used
+
+The primary usage is in `REPO-INSTRUCTIONS.md` where the setup instructions reference the template:
+
+**Before replacement (line 46):**
+```markdown
+1. `Start with a template` select `{{TEMPLATE_REPO_OWNER}}/{{TEMPLATE_REPO_NAME}}`
+```
+
+**After replacement (using default values):**
+```markdown
+1. `Start with a template` select `Chris-Wolfgang/repo-template`
+```
+
+**After replacement (using custom values):**
+```markdown
+1. `Start with a template` select `YourUsername/my-template`
+```
+
+### Validation
+
+The setup script validates that these placeholders are properly replaced (along with other core placeholders) before completing:
+
+**PowerShell (setup.ps1, lines 475-479):**
+```powershell
+$corePlaceholders = @(
+    'PROJECT_NAME', 'PROJECT_DESCRIPTION', 'PACKAGE_NAME',
+    'GITHUB_REPO_URL', 'REPO_NAME', 'GITHUB_USERNAME',
+    'DOCS_URL', 'LICENSE_TYPE',
+    'NUGET_STATUS', 'TEMPLATE_REPO_OWNER', 'TEMPLATE_REPO_NAME'
+)
+```
+
+**Files That Process These Placeholders:**
+1. **scripts/setup.ps1** - PowerShell setup script (prompts: lines 341-349; replacements hashtable: lines 390-391)
+2. **REPO-INSTRUCTIONS.md** - Target file where replacement occurs (line 46)
+
+---
+
+## Files Containing Placeholders
+
+### 1. README.md (After Rename)
+
+**Important:** `README-TEMPLATE.md` becomes `README.md` during setup.
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 1 | `{{PROJECT_NAME}}` | Main heading |
+| 3 | `{{PROJECT_DESCRIPTION}}` | Project description |
+| 5 | `{{LICENSE_TYPE}}` | License badge |
+| 7 | `{{GITHUB_REPO_URL}}` | GitHub badge link |
+| 13 | `{{PACKAGE_NAME}}` | Installation command |
+| 16 | `{{NUGET_STATUS}}` | NuGet availability |
+| 21 | `{{LICENSE_TYPE}}` | License section |
+| 27 | `{{GITHUB_REPO_URL}}` | Documentation link (2 occurrences) |
+| 28 | `{{DOCS_URL}}` | API documentation URL |
+| 35 | `{{QUICK_START_EXAMPLE}}` | Quick start code |
+| 41 | `{{FEATURES_TABLE}}` | Features table |
+| 44 | `{{FEATURE_EXAMPLES}}` | Feature examples |
+| 50 | `{{TARGET_FRAMEWORKS}}` | Framework list |
+| 119 | `{{GITHUB_REPO_URL}}` | Clone command |
+| 120 | `{{REPO_NAME}}` | Directory name |
+| 197 | `{{ACKNOWLEDGMENTS}}` | Acknowledgments section |
+
+### 2. CONTRIBUTING.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 1 | `{{PROJECT_NAME}}` | Main heading |
+| 3 | `{{PROJECT_NAME}}` | Introduction paragraph |
+
+### 3. .github/CODEOWNERS
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 5 | `{{GITHUB_USERNAME}}` | Default owner |
+| 8 | `{{GITHUB_USERNAME}}` | src/ directory (commented) |
+| 11 | `{{GITHUB_USERNAME}}` | docs/ directory (commented) |
+| 14 | `{{GITHUB_USERNAME}}` | workflows/ directory (commented) |
+| 17 | `{{GITHUB_USERNAME}}` | .github/ directory |
+
+### 4. REPO-INSTRUCTIONS.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 46 | `{{TEMPLATE_REPO_OWNER}}/{{TEMPLATE_REPO_NAME}}` | Template selection instruction |
+| ~135 | `{{GITHUB_USERNAME}}` | CODEOWNERS update instruction |
+
+### 5. scripts/Setup-BranchRuleset.ps1
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 37 | `{{GITHUB_USERNAME}}/{{REPO_NAME}}` | Default repository parameter |
+
+**Note:** This file is automatically updated during setup to contain your repository information. After setup, the script will automatically use the correct repository without needing to auto-detect or pass parameters.
+
+### 6. License Files (Selected During Setup)
+
+**LICENSE-MIT.txt:**
+- Line 3: `{{YEAR}}` and `{{COPYRIGHT_HOLDER}}`
+
+**LICENSE-APACHE-2.0.txt:**
+- Line 189: `{{YEAR}}` and `{{COPYRIGHT_HOLDER}}`
+
+**LICENSE-MPL-2.0.txt:**
+- No placeholders (license text is complete)
+- Copyright notice added separately if needed
+
+### 6. docfx_project/docfx.json
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 46 | `{{PROJECT_NAME}}` | Application name |
+| 47 | `{{PROJECT_NAME}}` | Application title |
+| 53 | `{{DOCS_URL}}` | Base URL for documentation |
+
+### 7. docfx_project/index.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 5 | `{{PROJECT_NAME}}` | Main heading |
+| 7 | `{{PROJECT_NAME}}` | Welcome message |
+| 13 | `{{GITHUB_REPO_URL}}` | GitHub repository link |
+| 15 | `{{PROJECT_NAME}}` | About section |
+| 17 | `{{PROJECT_DESCRIPTION}}` | About section |
+| 22 | `{{PACKAGE_NAME}}` | Installation command |
+| 35-37 | `{{GITHUB_REPO_URL}}` | Additional resources links (3 occurrences) |
+
+### 8. docfx_project/api/index.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 3 | `{{PROJECT_NAME}}` | Welcome message |
+
+### 9. docfx_project/docs/toc.yml
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| Various | `{{GITHUB_REPO_URL}}` | Project website link |
+
+### 10. docfx_project/docs/introduction.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| Various | `{{PROJECT_NAME}}`, `{{PROJECT_DESCRIPTION}}` | Introduction headings and descriptive text |
+| Various | `{{GITHUB_REPO_URL}}` | Links back to the GitHub repository from the introduction |
+
+### 11. docfx_project/docs/getting-started.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| Various | `{{PROJECT_NAME}}` | Getting started headings and examples |
+| Various | `{{PACKAGE_NAME}}` | NuGet installation and package reference snippets |
+| Various | `{{GITHUB_REPO_URL}}` | Links to source code, issues, and documentation on GitHub |
+
+### 9. docfx_project/docs/toc.yml
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 8 | `{{GITHUB_REPO_URL}}` | Project website link |
+
+### 10. docfx_project/docs/introduction.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 3 | `{{PROJECT_NAME}}` | Welcome message |
+| 7 | `{{PROJECT_DESCRIPTION}}` | Overview section |
+| 21 | `{{PROJECT_NAME}}` | Getting help section |
+| 25 | `{{GITHUB_REPO_URL}}` | GitHub repository link |
+| 26 | `{{GITHUB_REPO_URL}}` | GitHub issues link |
+
+### 11. docfx_project/docs/getting-started.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 3 | `{{PROJECT_NAME}}` | Guide title |
+| 17 | `{{PACKAGE_NAME}}` | NuGet installation command |
+| 23 | `{{PACKAGE_NAME}}` | Package Manager Console command |
+| 34 | `{{PROJECT_NAME}}` | Using statement in code example |
+| 42 | `{{PROJECT_NAME}}` | Next steps section |
+| 43 | `{{GITHUB_REPO_URL}}` | GitHub repository link |
+| 51 | `{{GITHUB_REPO_URL}}` | Additional resources |
+| 52 | `{{GITHUB_REPO_URL}}` | Contributing guidelines link |
+| 53 | `{{GITHUB_REPO_URL}}` | Issue reporting link |
+
+---
+
+## Replacement Process
+
+### Automated (Recommended)
+
+The setup scripts handle all replacements automatically:
+
+```powershell
+pwsh ./scripts/setup.ps1
+```
+
+### Manual Replacement
+
+If you must replace manually:
+
+1. **README File Swap:**
+   ```bash
+   rm README.md
+   mv README-TEMPLATE.md README.md
+   ```
+
+2. **License Setup:**
+   - Choose a license template (e.g., `LICENSE-MIT.txt`)
+   - Replace `{{YEAR}}` and `{{COPYRIGHT_HOLDER}}`
+   - Save as `LICENSE` (no extension)
+   - Delete all `LICENSE-*.txt` files
+
+3. **Global Find and Replace** in your editor:
+   - Search for: `{{PLACEHOLDER_NAME}}`
+   - Replace with: `Your Value`
+   - Files to search:
+     - `README.md` (now the renamed template)
+     - `CONTRIBUTING.md`
+     - `.github/CODEOWNERS`
+     - `REPO-INSTRUCTIONS.md`
+     - `LICENSE-SELECTION.md`
+     - `docfx_project/docfx.json`
+     - `docfx_project/index.md`
+     - `docfx_project/api/index.md`
+     - `docfx_project/api/README.md`
+     - `docfx_project/docs/toc.yml`
+     - `docfx_project/docs/introduction.md`
+     - `docfx_project/docs/getting-started.md`
+
+4. **Validation:**
+   ```bash
+   # Check for remaining required placeholders
+   # Note: README.md will still contain optional placeholders like {{QUICK_START_EXAMPLE}},
+   # {{FEATURES_TABLE}}, {{FEATURE_EXAMPLES}}, {{TARGET_FRAMEWORKS}}, {{ACKNOWLEDGMENTS}}
+   # which you fill in as you develop your project
+   grep -r "{{.*}}" CONTRIBUTING.md .github/CODEOWNERS REPO-INSTRUCTIONS.md LICENSE-SELECTION.md docfx_project/ || echo "No required placeholders found in core files"
+   
+   # Check README.md separately for required placeholders only
+   grep -E "{{(PROJECT_NAME|PROJECT_DESCRIPTION|PACKAGE_NAME|GITHUB_REPO_URL|REPO_NAME|DOCS_URL|LICENSE_TYPE|NUGET_STATUS)}}" README.md && echo "⚠️  Found required placeholders in README.md - please replace them" || echo "✓ All required placeholders replaced in README.md"
+   ```
+
+---
+
+## Example Replacement Values
+
+Here's a complete example for a hypothetical project:
+
+```
+{{PROJECT_NAME}}              → Wolfgang.Net.HttpClient.Extensions
+{{PROJECT_DESCRIPTION}}       → Extension methods for HttpClient with retry policies and resilience
+{{PACKAGE_NAME}}              → Wolfgang.Net.HttpClient.Extensions
+{{GITHUB_REPO_URL}}           → https://github.com/Chris-Wolfgang/HttpClient-Extensions
+{{REPO_NAME}}                 → HttpClient-Extensions
+{{GITHUB_USERNAME}}           → @Chris-Wolfgang
+{{DOCS_URL}}                  → https://chris-wolfgang.github.io/HttpClient-Extensions/
+{{LICENSE_TYPE}}              → MIT
+{{YEAR}}                      → 2024
+{{COPYRIGHT_HOLDER}}          → Chris Wolfgang
+{{NUGET_STATUS}}              → Coming soon to NuGet.org
+{{TEMPLATE_REPO_OWNER}}       → Chris-Wolfgang
+{{TEMPLATE_REPO_NAME}}        → repo-template
+```
+
+---
+
+## Validation Checklist
+
+After replacement, verify:
+
+- [ ] All required placeholders are replaced
+- [ ] No `{{...}}` patterns remain in core files
+- [ ] README.md exists (from README-TEMPLATE.md)
+- [ ] LICENSE file exists (no .txt extension)
+- [ ] CODEOWNERS has your GitHub username
+- [ ] CONTRIBUTING.md has your project name
+- [ ] All URLs are correct and accessible
+- [ ] License type matches your LICENSE file
+
+---
+
+## Troubleshooting
+
+### Issue: Placeholder not found in file
+
+**Cause:** The file may have been manually edited before running setup.
+
+**Solution:** Check the file manually or re-clone from template.
+
+### Issue: Wrong value auto-detected
+
+**Cause:** Git configuration or remote URL is incorrect.
+
+**Solution:** The setup script allows manual override of all values.
+
+### Issue: Remaining placeholders after setup
+
+**Cause:** Some placeholders are intentionally left for users to fill (e.g., `{{QUICK_START_EXAMPLE}}`).
+
+**Solution:** Fill these in as you develop your project.
+
+---
+
+## Additional Resources
+
+- **Setup Script:** `pwsh ./scripts/setup.ps1`
+- **License Selection Guide:** [LICENSE-SELECTION.md](LICENSE-SELECTION.md)
+- **Repository Instructions:** [REPO-INSTRUCTIONS.md](REPO-INSTRUCTIONS.md)
+- **Template README:** [README.md](README.md) (describes template)
+- **Project README Template:** [README-TEMPLATE.md](README-TEMPLATE.md)
+
+---
+
+## Contributing
+
+Found an issue with placeholder documentation? Please open an issue or submit a pull request!

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -1,0 +1,179 @@
+# Workflow Security
+
+## Overview
+
+This document describes the security measures implemented in the GitHub Actions workflows for this repository, particularly focusing on the PR validation workflow (`.github/workflows/pr.yaml`).
+
+## Security Architecture
+
+### 1. Workflow YAML Protection
+
+**Mechanism**: `pull_request_target` trigger
+
+The PR workflow uses `pull_request_target` instead of `pull_request`. This means:
+- The workflow YAML file is always executed from the base branch (main)
+- Pull requests cannot modify the workflow logic that validates them
+- Prevents malicious PRs from weakening or bypassing validation checks
+
+**Code Reference**:
+```yaml
+on:
+  pull_request_target:  # Runs from the main branch, not from PR branch
+    branches:
+      - main
+```
+
+### 2. Configuration File Protection
+
+**Problem**: While `pull_request_target` protects the workflow YAML, the checked-out code includes configuration files (`.editorconfig`, `BannedSymbols.txt`, etc.) that control:
+- Code analyzer behavior
+- Code quality standards
+- Security scanning rules
+
+A malicious PR could modify these files to disable security checks.
+
+**Solution**: After checking out the PR code, we fetch and overwrite configuration files from the trusted main branch.
+
+**Protected Configuration Files**:
+- `.editorconfig` - Code style and analyzer rules
+- `Directory.Build.props` - MSBuild properties
+- `Directory.Build.targets` - MSBuild targets
+- `BannedSymbols.txt` - Banned API usage rules
+- `*.globalconfig` - Global analyzer configuration
+- `*.ruleset` - Code analysis rulesets
+
+**Implementation** (added to all workflow jobs):
+```yaml
+- name: Fetch trusted configuration files from main branch
+  run: |
+    echo "Fetching configuration files from main branch to prevent malicious overrides..."
+    
+    # Fetch the main branch
+    git fetch origin main:main-branch
+    
+    # List of configuration files that should come from trusted main branch
+    config_files=(
+      ".editorconfig"
+      "Directory.Build.props"
+      "Directory.Build.targets"
+      "BannedSymbols.txt"
+      "*.globalconfig"
+      "*.ruleset"
+    )
+    
+    # Copy each configuration file from main branch if it exists
+    for config_file in "${config_files[@]}"; do
+      # [Copy logic - see workflow file for full implementation]
+    done
+```
+
+### 3. Credential Protection
+
+**Mechanism**: `persist-credentials: false`
+
+All checkout steps include `persist-credentials: false` to prevent the checkout token from being written to git config:
+
+```yaml
+- name: Checkout code
+  uses: actions/checkout@v4
+  with:
+    ref: refs/pull/${{ github.event.pull_request.number }}/head
+    persist-credentials: false
+```
+
+**Note**: This prevents the token from being stored in git config, but does NOT prevent steps from accessing `GITHUB_TOKEN` if explicitly exposed.
+
+### 4. Minimal Permissions
+
+The workflow runs with minimal required permissions:
+
+```yaml
+permissions:
+  contents: read
+```
+
+This limits the impact if the `GITHUB_TOKEN` is somehow exposed or misused.
+
+## Attack Scenarios Prevented
+
+### Scenario 1: Malicious Workflow Modification
+**Attack**: PR modifies `.github/workflows/pr.yaml` to disable security checks
+**Prevention**: `pull_request_target` ensures workflow runs from main branch
+**Status**: ✅ Protected
+
+### Scenario 2: Configuration File Tampering
+**Attack**: PR modifies `.editorconfig` to disable security analyzers
+**Prevention**: Configuration files are fetched from main branch after checkout
+**Status**: ✅ Protected (as of this PR)
+
+### Scenario 3: Credential Theft
+**Attack**: PR contains malicious code that tries to access GitHub credentials
+**Prevention**: `persist-credentials: false` + minimal permissions
+**Status**: ✅ Protected
+
+### Scenario 4: Code Analysis Bypass
+**Attack**: PR modifies `BannedSymbols.txt` or `.ruleset` to allow dangerous APIs
+**Prevention**: These files are fetched from main branch after checkout
+**Status**: ✅ Protected (as of this PR)
+
+## Testing
+
+Security tests have been created and validated:
+
+1. **Configuration Fetch Test**: Verifies that configuration files can be successfully fetched from the main branch
+2. **Malicious Modification Test**: Simulates a PR that modifies `.editorconfig` to disable analyzers and confirms it's replaced with the trusted version
+
+Both tests pass successfully.
+
+## Maintenance
+
+### Making Changes to Protected Configuration Files
+
+To update protected configuration files (`.editorconfig`, `BannedSymbols.txt`, etc.), follow this workflow:
+
+1. **Create a PR with your configuration changes**
+   - Make changes to the configuration file(s) in your PR branch
+   - The PR workflow will still fetch and use the current main branch version for testing
+   - This means your PR will be tested against the **existing** configuration standards
+
+2. **Get your PR reviewed and merged to main**
+   - Once merged, your configuration changes become the new "trusted" version on main
+   - Future PRs will automatically use your updated configuration
+
+3. **Why this works:**
+   - Configuration changes are intentionally one commit behind during PR validation
+   - This ensures you can't weaken security standards in the same PR that adds problematic code
+   - After merge, the new standards apply to all subsequent PRs
+
+**Example Workflow:**
+```
+PR #1: Update .editorconfig to add new rule
+  ↓ (tested with old .editorconfig from main)
+  ↓ (approved and merged)
+  ↓
+Main: Now has updated .editorconfig
+
+PR #2: New feature
+  ↓ (tested with updated .editorconfig from main)
+  ↓ (builds/tests using new rules)
+```
+
+**Important Notes:**
+- If you need to relax a security rule AND add code that violates the old rule in the same change, you'll need two PRs:
+  1. First PR: Update the configuration file only
+  2. Second PR: Add the code that requires the relaxed rules
+- This is intentional security design to prevent simultaneous weakening of standards and addition of problematic code
+
+### Adding New Protected Configuration Files
+
+When adding new configuration files that control code quality or security:
+
+1. Add the file name to the `config_files` array in all workflow jobs (detect-projects, test-linux-core, test-windows, test-macos-core, security-scan)
+2. Test that the file is correctly fetched from main branch
+3. Update this documentation
+
+## References
+
+- [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+- [Keeping your GitHub Actions secure](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
+- [Understanding pull_request_target](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)


### PR DESCRIPTION
## Summary
- Commits 4 reference template docs that have been sitting untracked in `docs/` (`LICENSE-SELECTION.md`, `README-FORMATTING.md`, `TEMPLATE-PLACEHOLDERS.md`, `WORKFLOW_SECURITY.md`). The other 2 docs (`RELEASE-WORKFLOW-SETUP.md`, `SECURITY.md`) were already tracked.
- Adds a `docs/*` exception block to `.gitignore`: ignore everything in `docs/` by default, but explicitly keep these 6 reference files (and `docs/.gitkeep`) tracked.

## Why
Several downstream repos (Etl-DbClient observed; likely others) had this exception block locally to protect tracked docs from CI/CD-generated artifacts. The naive `.gitignore` canonical-sync PRs in those repos would have stripped this safeguard. With the block in canonical, the sync becomes idempotent.

This is option 2 from the bulk-sync triage: surface a clearly canonical-worthy pattern that was living locally in downstream repos.

## What didn't go in
- `.nuget/nuget.exe` (legacy NuGet binary location) — not needed in canonical; if any individual repo has the file, that repo can re-add the line.
- `resharper-results.xml` — same reasoning.

## Test plan
- [ ] CI green
- [ ] After merge, the existing Etl-DbClient `.gitignore` sync PR (and any other ETL repos with the same pattern) merges cleanly without losing the tracked-docs safeguard

🤖 Generated with [Claude Code](https://claude.com/claude-code)