### PR TITLE
docs: polish canonical /docs reference set

### DIFF
--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -30,25 +30,21 @@ Or check without making changes:
 dotnet format
 ```
 
-### Check Formatting (like CI does)
+### Verify Without Modifying Files
 
 ```bash
 dotnet format --verify-no-changes
 ```
 
+This is useful as a pre-commit guard or in a CI step if the repo opts in to enforcing formatting at PR time. By default, the standard PR workflow does **not** run `dotnet format --verify-no-changes`; formatting is treated as a developer-side hygiene step driven by `.editorconfig` and IDE-on-save behavior.
+
 ## Configuration
 
-Code style rules are defined in `.editorconfig` at the repository root.
+Code style rules are defined in `.editorconfig` at the repository root. `.editorconfig` is the source of truth — anything in this document that conflicts with `.editorconfig` should be considered out of date.
 
-## CI/CD
+## Local Enforcement
 
-Code formatting is enforced locally via `.editorconfig` and `dotnet format`. Run the formatting script before submitting a PR.
-
-### If CI Fails
-
-1. Run `.\scripts\format.ps1` locally
-2. Review the changes
-3. Commit and push the formatted code
+Code formatting is enforced locally via `.editorconfig` and `dotnet format`. Run the formatting script before submitting a PR. If the repo has opted into a CI formatting check, the PR workflow will fail on unformatted code; resolve by running `.\scripts\format.ps1` locally and pushing the resulting changes.
 
 ## IDE Integration
 
@@ -60,9 +56,10 @@ Most IDEs automatically read `.editorconfig`:
 
 ## Formatting Rules
 
-Key style rules:
-- **Indentation**: 4 spaces for C# (with `switch` case contents not additionally indented when inside a block, per `.editorconfig`), 2 for XML/JSON
-- **Braces**: Opening brace on new line
-- **Line endings**: LF (Unix style)
+Authoritative rules live in `.editorconfig` (and `.gitattributes` for line endings, which may override the `.editorconfig` defaults for specific file types — e.g. forcing CRLF on `*.ps1`). The list below is a quick orientation; check those files for the binding values:
+
+- **Indentation**: 4 spaces for C#, 2 for XML/JSON (per `.editorconfig`)
+- **Braces**: Opening brace on its own line
+- **Line endings**: LF for source/docs, with file-type overrides in `.gitattributes` (e.g. CRLF for `*.ps1`)
 - **Trailing whitespace**: Removed
 - **Using directives**: System namespaces first, sorted alphabetically

--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -1,6 +1,6 @@
 # Release Workflow Setup Guide
 
-This guide explains how to configure the repository after merging the updated `release.yaml` workflow.
+This guide explains how to configure a repository to use the standard `release.yaml` workflow. The same checklist applies whether you are bootstrapping a new repo from `repo-template` or auditing an existing one.
 
 ## Overview
 
@@ -11,9 +11,9 @@ The release workflow triggers when you **publish a GitHub Release** and implemen
 - ✅ Automatically publishes to NuGet.org after validation passes
 - ✅ Eliminates duplicate build work for faster releases
 
-## Required Post-Merge Configuration
+## Required Configuration
 
-After merging this PR, complete the following setup step:
+Complete the following one-time setup so that the workflow can publish releases:
 
 ### Add NuGet API Key Secret
 
@@ -31,9 +31,9 @@ After merging this PR, complete the following setup step:
 
 ### Verify Branch Protection Rules
 
-**Location:** Settings → Branches → main
+**Location:** Settings → Branches → main (or Settings → Rules → Rulesets)
 
-> **Note:** By default, the template is configured for single developer repositories. The branch protection setup script (`scripts/Setup-BranchRuleset.ps1`) includes interactive prompts that allow you to choose between single-developer or multi-developer settings during execution. Simply run the script and select option [1] for single-developer mode (0 approvals) or option [2] for multi-developer mode (1+ approvals and code owner review required).
+> **Note:** Repos created from `repo-template` ship with `scripts/Setup-BranchRuleset.ps1`, which configures branch protection interactively (option `[1]` for single-developer mode, `[2]` for multi-developer mode). The script may not be present in older repos — if it is missing, configure the equivalent settings manually using the checklist below.
 
 Ensure the following settings are enabled:
 

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -41,8 +41,11 @@ A malicious PR could modify these files to disable security checks.
 - `BannedSymbols.txt` - Banned API usage rules
 - `*.globalconfig` - Global analyzer configuration
 - `*.ruleset` - Code analysis rulesets
+- `.github/workflows/*.yml` and `.github/workflows/*.yaml` - Workflow definitions
 
-**Implementation** (added to all workflow jobs):
+In addition to the overwrite step, a separate "Detect protected configuration file changes" step in `pr.yaml` causes the PR to fail if any of these files differ from `main`, signalling that a maintainer must manually review the change. Dependabot is exempted (its bumps to `Directory.Build.props` are legitimate).
+
+**Implementation** (in jobs that consume project source — e.g. `detect-projects`, the test stages, and the security scans; *not* the `secrets-scan` job, which only fetches `.gitleaks.toml`):
 ```yaml
 - name: Fetch trusted configuration files from main branch
   run: |
@@ -75,7 +78,7 @@ All checkout steps include `persist-credentials: false` to prevent the checkout 
 
 ```yaml
 - name: Checkout code
-  uses: actions/checkout@v4
+  uses: actions/checkout@v6
   with:
     ref: refs/pull/${{ github.event.pull_request.number }}/head
     persist-credentials: false
@@ -104,7 +107,7 @@ This limits the impact if the `GITHUB_TOKEN` is somehow exposed or misused.
 ### Scenario 2: Configuration File Tampering
 **Attack**: PR modifies `.editorconfig` to disable security analyzers
 **Prevention**: Configuration files are fetched from main branch after checkout
-**Status**: ✅ Protected (as of this PR)
+**Status**: ✅ Protected
 
 ### Scenario 3: Credential Theft
 **Attack**: PR contains malicious code that tries to access GitHub credentials
@@ -114,7 +117,7 @@ This limits the impact if the `GITHUB_TOKEN` is somehow exposed or misused.
 ### Scenario 4: Code Analysis Bypass
 **Attack**: PR modifies `BannedSymbols.txt` or `.ruleset` to allow dangerous APIs
 **Prevention**: These files are fetched from main branch after checkout
-**Status**: ✅ Protected (as of this PR)
+**Status**: ✅ Protected
 
 ## Validation
 
@@ -166,9 +169,10 @@ PR #2: New feature
 
 When adding new configuration files that control code quality or security:
 
-1. Add the file name to the `config_files` array in all workflow jobs (detect-projects, test-linux-core, test-windows, test-macos-core, security-scan)
-2. Test that the file is correctly fetched from main branch
-3. Update this documentation
+1. Add the file name to the `config_files` array in every job that runs `Fetch trusted configuration files from main branch` (the project-detection job, each test-stage job, and the security-scan jobs — search `pr.yaml` for that step name to find them all). The `secrets-scan` job does not consume project config files and does not need to be updated.
+2. Add the file path to the "Detect protected configuration file changes" guard in `pr.yaml` so PRs that touch the file fail with a maintainer-review banner.
+3. Test that the file is correctly fetched from main branch.
+4. Update this documentation.
 
 ## References
 


### PR DESCRIPTION
## Summary
Polishes the three canonical reference docs in `/docs` so they reflect the actual runtime behavior of the workflows and don't carry residual bootstrap-PR language.

## Why
The previous /docs sync sweep (21 PRs, all closed) surfaced ~5 categories of Copilot complaints that all traced back to the canonical content rather than anything repo-specific:

1. **Aspirational / PR-state language** — "after merging this PR", "added to all workflow jobs", "✅ Protected (as of this PR)". Written when the docs originally bootstrapped the protections; reads wrong in any other context.
2. **References to scripts that don't exist in derived repos** — `scripts/Setup-BranchRuleset.ps1` is only present in repos created from `repo-template` (and not all of them).
3. **Claimed CI enforces `dotnet format`** — the standard `pr.yaml` does not run `dotnet format --verify-no-changes`.
4. **Stale technical details** — `actions/checkout@v4` example (current workflows use `@v6`); protected-files list missing `.github/workflows/*.{yml,yaml}`.
5. **Repo-specific rules stated as universal** — line endings (`.gitattributes` overrides LF→CRLF for `*.ps1` in many repos), indentation rules duplicated from `.editorconfig`.

## Changes
- **README-FORMATTING.md** — drop the 'like CI does' framing, rewrite the 'CI/CD' section as 'Local Enforcement', defer indentation/line-ending rules to `.editorconfig` + `.gitattributes`.
- **RELEASE-WORKFLOW-SETUP.md** — reword intro and 'Required Configuration' as steady-state guide; soften the `Setup-BranchRuleset.ps1` reference for repos that don't have it.
- **WORKFLOW_SECURITY.md** — add workflow-yaml patterns to the protected list, describe the separate detection-guard step + Dependabot exemption, scope 'added to all workflow jobs' accurately (excludes `secrets-scan`), bump example checkout pin v4→v6, drop 'as of this PR' status markers.

## Next
After this lands, re-run the cross-repo /docs sync to bring the polished version into 21 derived repos.