### PR TITLE
pr.yaml: write protected config files as UTF-8 without BOM

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -642,7 +642,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -657,7 +657,7 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
               }
             }
           }
@@ -687,7 +687,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -702,7 +702,7 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
               }
             }
           }


### PR DESCRIPTION
## Summary
The "Fetch trusted configuration files from main branch" step in `pr.yaml` (in both the v3 gated workflow's main-tests job and the secondary tests job) writes the protected config files back to disk via:

```pwsh
git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
```

In PowerShell, `-Encoding UTF8` writes UTF-8 **with** a BOM. The .NET analyzer engine that reads `.editorconfig` appears to silently ignore files that begin with a BOM — so the project's severity overrides (e.g. `dotnet_diagnostic.MA0002.severity = suggestion`) don't apply on CI even though they apply locally. Analyzers fire at their default severity instead, and `TreatWarningsAsErrors` then escalates them.

This was diagnosed against [Chris-Wolfgang/In-memory-Logger PR #32 / run 24996715587](https://github.com/Chris-Wolfgang/In-memory-Logger/actions/runs/24996715587/job/73195928572): local Release builds were clean while CI reported MA0002, MA0049, S2365, S1066, MA0158, S1481, S2699 as errors. After repointing the build to the BOM-free version of `.editorconfig`, the same source compiled clean.

## Fix
Switch the four call sites to `Out-File -Encoding UTF8NoBOM`. PS 6+ supports this encoding token; GitHub-hosted `shell: pwsh` runners use PowerShell 7+, so it's safe.

## Downstream impact
The bug exists in every consumer repo's `pr.yaml`. They'll pick up the fix on their next template-sync. No retroactive flush needed — once the BOM-free `.editorconfig` lands on `main`, subsequent PRs will see the analyzer config applied as intended.

## Test plan
- [ ] CI on this PR passes (the same protected-files mechanism runs on this PR)
- [ ] After merge, sync into one consumer repo (e.g. In-memory-Logger) and verify a Release build of an existing PR no longer trips analyzer rules that the project's `.editorconfig` marks as `suggestion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)