### PR TITLE
fix(docfx): swap return values for fewer-prerelease-id case (descending order)

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -170,8 +170,13 @@ jobs:
             $maxLen = [Math]::Max($aIds.Length, $bIds.Length)
 
             for ($i = 0; $i -lt $maxLen; $i++) {
-              if ($i -ge $aIds.Length) { return -1 } # a has fewer identifiers -> lower precedence
-              if ($i -ge $bIds.Length) { return 1 }  # b has fewer identifiers -> lower precedence
+              # SemVer §11.4.4: fewer prerelease identifiers = lower precedence.
+              # In *descending* order (newest first), the lower-precedence
+              # value sorts AFTER the higher-precedence one, so the comparator
+              # must return positive when 'a' is the shorter (lower-precedence)
+              # one and negative when 'b' is.
+              if ($i -ge $aIds.Length) { return 1 }  # a has fewer identifiers -> lower precedence -> sorts later
+              if ($i -ge $bIds.Length) { return -1 } # b has fewer identifiers -> lower precedence -> sorts later
 
               $aId = $aIds[$i]
               $bId = $bIds[$i]


### PR DESCRIPTION
## Summary
The SemVer prerelease comparator in `docfx.yaml` (the version-tag sorter that builds `versions.json`) had the return values inverted for the case where the two prereleases have a different number of identifiers.

## Detail
The comparator sorts versions in **descending order** (newest first). The relevant block:

```powershell
for ($i = 0; $i -lt $maxLen; $i++) {
  if ($i -ge $aIds.Length) { return -1 } # a has fewer identifiers -> lower precedence
  if ($i -ge $bIds.Length) { return 1 }  # b has fewer identifiers -> lower precedence
  ...
}
```

Per SemVer §11.4.4, fewer prerelease identifiers = lower precedence (e.g., `1.0.0-alpha` < `1.0.0-alpha.1`). For descending order, lower-precedence values sort AFTER higher-precedence ones, so the comparator should return **positive** when `a` is the shorter (lower-precedence) one — but it was returning `-1`, which placed `a` BEFORE `b`.

The in-code comments correctly identified the precedence relationship; only the return values were wrong.

## Concrete impact on `versions.json` ordering

| Before (wrong) | After (correct) |
|---|---|
| `1.0.0-alpha` | `1.0.0-alpha.1` |
| `1.0.0-alpha.1` | `1.0.0-alpha` |
| `1.0.0-rc` | `1.0.0-rc.2` |
| `1.0.0-rc.2` | `1.0.0-rc` |

Visible only when a project ships multiple prereleases of the same base version with differing identifier counts. Most Wolfgang.* repos don't currently have such combinations, but the version picker would render the wrong order if/when they do.

## Why now
Caught by Copilot review on [IEnumerable-Extensions PR #95](https://github.com/Chris-Wolfgang/IEnumerable-Extensions/pull/95) (which sync'd this docfx.yaml from canonical). The fix needs to land on canonical first; downstream repos pick it up via template-sync (or per-repo PRs).

## Out of scope
Copilot also flagged a cleanup-push-before-deploy split (the cleanup step pushes its own commit, then the deploy step pushes another, leaving a partial-cleanup window if the deploy fails). That's a real concern but requires combining the cleanup and deploy steps into a single worktree — bigger refactor, separate PR.

## Note about the protected-files guard
This PR touches `.github/workflows/docfx.yaml` so the `Detect .NET Projects` guard will fail it. Maintainer override required.

## Test plan
- [ ] Maintainer override + merge
- [ ] Open downstream sync PR(s) (starting with IEnumerable-Extensions where the bug was caught)
- [ ] Verify on a project with mixed-length prereleases when one ships