### PR TITLE
fix(eol): make *.ps1 canonical LF + no BOM for shebang compat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,12 +26,12 @@ indent_size = 2
 indent_size = 2
 
 # PowerShell files
-# PowerShell uses CRLF to maintain compatibility with Windows and PowerShell conventions
-# This overrides the global end_of_line = lf setting and aligns with .gitattributes line 14
+# Use LF + no BOM so the `#!/usr/bin/env pwsh` shebang works on Linux/macOS.
+# (CR breaks kernel exec lookup; BOM before `#!` prevents shebang recognition.)
+# Modern PowerShell 7+ handles LF on Windows transparently; users with
+# autocrlf=true still get CRLF in their working tree on checkout.
 [*.ps1]
 indent_size = 4
-end_of_line = crlf
-charset = utf-8-bom
 
 # C# files
 [*.cs]

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,11 +9,14 @@
 *.fsx text eol=lf
 
 # Scripts
-# PowerShell scripts: CRLF line endings (intentional override)
-# Both .gitattributes and .editorconfig consistently configure PowerShell files
-# to use CRLF (Windows-style) line endings for PowerShell convention compliance.
-# See .editorconfig [*.ps1] section for the matching configuration.
-*.ps1 text eol=crlf
+# PowerShell scripts: LF line endings, no BOM. Required for the
+# `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
+# parses CR as part of the interpreter name (looking for `pwsh\r`),
+# and a UTF-8 BOM before `#!` prevents shebang recognition entirely.
+# Modern PowerShell 7+ handles LF on Windows transparently; Git's
+# autocrlf still gives Windows users CRLF in their working tree if
+# desired without forcing CRLF into the index.
+*.ps1 text
 
 
 # Build and configuration files


### PR DESCRIPTION
## Summary
Drop the `*.ps1` CRLF + UTF-8-BOM overrides in `.gitattributes` and `.editorconfig`. Required for the `#!/usr/bin/env pwsh` shebang at the top of every script in `scripts/` to actually work as an executable on Linux/macOS.

## The shebang problem

Two ways the current overrides break shebang invocation:

1. **CRLF line endings:** kernel reads `#!/usr/bin/env pwsh\r` and tries to find an interpreter literally named `pwsh\r` — fails. (`\r` is part of the parsed interpreter path.)
2. **UTF-8 BOM:** the bytes `EF BB BF` appear *before* `#!`, so the kernel doesn't recognize the file as a shebang script at all.

Either alone breaks `./script.ps1`. Together, they make it doubly broken on non-Windows.

## Why "PowerShell uses CRLF" was outdated rationale

That convention came from the Windows-PowerShell-5.1-and-earlier era when PS only ran on Windows. The current canonical sources have all standardized on LF:

- PowerShell team's own `PowerShell/PowerShell` repo: LF, no BOM
- `PSScriptAnalyzer`: LF, no BOM
- Microsoft's cross-platform PS samples: LF, no BOM

Modern PowerShell 7+ (PS Core) is cross-platform and handles LF on Windows transparently.

## What changes

| File | Before | After |
|---|---|---|
| `.gitattributes` | `*.ps1 text eol=crlf` | `*.ps1 text` (defaults to `eol=lf` via the global rule) |
| `.editorconfig [*.ps1]` | `end_of_line = crlf`, `charset = utf-8-bom` | (both removed; defaults to LF + utf-8 no BOM) |

Comments rewritten to explain the shebang rationale.

## What does NOT change

- **Files in the index:** already LF. The CRLF rule was aspirational policy that never matched reality (the rule was added later without renormalizing existing LF-stored files). No file content rewrites in this PR.
- **Windows users:** `core.autocrlf=true` (Git for Windows default) still gives CRLF in working tree on checkout. Only the index/wire format is LF — which is what it's always been.
- **Indent:** still 4 spaces for `*.ps1`.

## Why this PR is so small

Today's state: index is `i/lf`, attr says `eol=crlf`, working tree on Windows is `w/crlf` (autocrlf). After this PR: index `i/lf`, attr says `eol=lf`, working tree `w/crlf` on Windows / `w/lf` on Linux/macOS. The only difference is the attr declaration aligning with what's already in the index.

## Note about the protected-files guard

This PR touches `.editorconfig` (protected) — the `Detect .NET Projects` guard will fail it. Maintainer override required.

## Follow-up
After merge, sync to the 24 affected active repos (each has the same `[*.ps1]` overrides). Per-repo PRs, each ~12 lines. Each will need maintainer override too — same pattern as previous fleet-wide config-touching syncs.

## Test plan
- [ ] Maintainer override + merge canonical
- [ ] Per-repo sync PRs (24 active repos)
- [ ] After all land: `git ls-files --eol scripts/*.ps1` shows `i/lf w/* attr/text eol=lf` everywhere
- [ ] Manual smoke test: `chmod +x scripts/setup.ps1 && ./scripts/setup.ps1 --help` works on Linux/macOS via shebang