### PR TITLE
fix: address Copilot review on #347 (explicit eol=lf + comment honesty)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,10 +26,11 @@ indent_size = 2
 indent_size = 2
 
 # PowerShell files
-# Use LF + no BOM so the `#!/usr/bin/env pwsh` shebang works on Linux/macOS.
-# (CR breaks kernel exec lookup; BOM before `#!` prevents shebang recognition.)
-# Modern PowerShell 7+ handles LF on Windows transparently; users with
-# autocrlf=true still get CRLF in their working tree on checkout.
+# Only the indent override is needed; LF + UTF-8 (no BOM) come from the
+# global [*] section above. LF + no-BOM is required for the
+# `#!/usr/bin/env pwsh` shebang at the top of every script in scripts/
+# to work on Linux/macOS — CR breaks the kernel's exec lookup, and a
+# leading BOM prevents shebang recognition entirely.
 [*.ps1]
 indent_size = 4
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,7 +16,7 @@
 # Modern PowerShell 7+ handles LF on Windows transparently; Git's
 # autocrlf still gives Windows users CRLF in their working tree if
 # desired without forcing CRLF into the index.
-*.ps1 text
+*.ps1 text eol=lf
 
 
 # Build and configuration files


### PR DESCRIPTION
## Summary
Two stylistic follow-ups Copilot flagged on [#347](https://github.com/Chris-Wolfgang/repo-template/pull/347) that I pushed after the merge — they didn't make it in.

## Changes

### 1. `.gitattributes`: `*.ps1 text` → `*.ps1 text eol=lf`

Every other entry in `.gitattributes` spells out `eol=lf` explicitly:

```
*.cs text eol=lf
*.csx text eol=lf
*.csproj text eol=lf
*.sln text eol=lf
... etc.
```

The bare `*.ps1 text` form relied on the global `* text=auto eol=lf` resolving to LF — behaviorally equivalent, but inconsistent with the file's own convention and ambiguous to anyone reading later.

### 2. `.editorconfig` `[*.ps1]` comment rewrite

The comment said "Use LF + no BOM..." but the section no longer sets `end_of_line` or `charset` — those come from the `[*]` global section above. The old comment described what the previous CRLF/BOM overrides used to enforce, not what the current section does.

Every other `[*.xxx]` section in `.editorconfig` only overrides what differs from `[*]` (just `indent_size`), so the [*.ps1] section is intentionally minimal. New comment explains both the convention and *why* LF + no-BOM matters in this repo (the `#!/usr/bin/env pwsh` shebang at the top of every script in `scripts/`).

## What does NOT change
- Behavior — LF + UTF-8-no-BOM was the effective config after #347; this PR only sharpens the declarations and comment
- File content — no `.ps1` files rewritten

## Note about the protected-files guard
Touches `.editorconfig` (protected). Maintainer override required — same path as #347 itself.

## Follow-up
Once this lands, the 24 fleet-sync PRs to apply the #347 + this fix will use these final declarations directly.

## Test plan
- [ ] Maintainer override + merge
- [ ] After merge, fleet-sync PRs use the post-#347-and-this state