### PR TITLE
fix(docs/.gitattributes): comment accuracy on EOL policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,16 +9,16 @@
 *.fsx text eol=lf
 
 # Scripts
-# PowerShell scripts: enforce LF line endings. (BOM-free UTF-8
-# encoding is enforced separately by .editorconfig's global
-# `charset = utf-8` — .gitattributes can only control EOL, not
-# byte-order marks.) LF is required for the `#!/usr/bin/env pwsh`
-# shebang to work on Linux/macOS — the kernel parses CR as part of
-# the interpreter name (looking for `pwsh\r`), and a UTF-8 BOM before
-# `#!` would prevent shebang recognition entirely. Modern PowerShell
-# 7+ handles LF on Windows transparently; Git's autocrlf still gives
-# Windows users CRLF in their working tree if desired without forcing
-# CRLF into the index.
+# PowerShell scripts: enforce LF line endings in both the index AND
+# the working tree (the explicit `eol=lf` overrides any user-level
+# `core.autocrlf=true` setting that would otherwise convert to CRLF
+# on checkout). BOM-free UTF-8 encoding is enforced separately by
+# .editorconfig's global `charset = utf-8` — .gitattributes can only
+# control EOL, not byte-order marks. LF is required for the
+# `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
+# parses CR as part of the interpreter name (looking for `pwsh\r`),
+# and a UTF-8 BOM before `#!` would prevent shebang recognition
+# entirely. Modern PowerShell 7+ handles LF on Windows transparently.
 *.ps1 text eol=lf
 
 

--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -56,10 +56,10 @@ Most IDEs automatically read `.editorconfig`:
 
 ## Formatting Rules
 
-Authoritative rules live in `.editorconfig` (and `.gitattributes` for line endings, which may override the `.editorconfig` defaults for specific file types — e.g. forcing CRLF on `*.ps1`). The list below is a quick orientation; check those files for the binding values:
+Authoritative rules live in `.editorconfig` (and `.gitattributes` for line endings, which enforces LF across all text file types in this repo — including `*.ps1`, which historically used CRLF but is now LF for cross-platform shebang compatibility). The list below is a quick orientation; check those files for the binding values:
 
 - **Indentation**: 4 spaces for C#, 2 for XML/JSON (per `.editorconfig`)
 - **Braces**: Opening brace on its own line
-- **Line endings**: LF for source/docs, with file-type overrides in `.gitattributes` (e.g. CRLF for `*.ps1`)
+- **Line endings**: LF for all text files (per `.gitattributes`), including PowerShell scripts
 - **Trailing whitespace**: Removed
 - **Using directives**: System namespaces first, sorted alphabetically


### PR DESCRIPTION
## Summary
Two doc/comment inaccuracies caught by Copilot review on [Try-Pattern PR #110](https://github.com/Chris-Wolfgang/Try-Pattern/pull/110) (comprehensive sync from canonical).

## Changes

### `docs/README-FORMATTING.md`
The example said `.gitattributes` "forces CRLF on `*.ps1`" — but the current policy (established in #347/#348) is the opposite: `*.ps1 text eol=lf`. Reworded to say all text files are LF, with a brief note that `*.ps1` historically used CRLF before the switch.

### `.gitattributes`
The `*.ps1` comment said:
> Git's autocrlf still gives Windows users CRLF in their working tree if desired without forcing CRLF into the index.

This is wrong — the explicit `eol=lf` on the following line **overrides** `core.autocrlf` entirely. Users get LF in both the index AND the working tree regardless of their `autocrlf` setting. Reworded to state that explicitly.

## Note about the protected-files guard
This PR touches `.gitattributes` (a protected file). The `Detect .NET Projects` guard will block — maintainer override required.

## Cascade
After this lands, future downstream sync PRs pulling these files won't reintroduce the misleading text.