### PR TITLE
.gitattributes: don't overstate scope of attributes vs .editorconfig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,8 +13,10 @@
 # the working tree (the explicit `eol=lf` overrides any user-level
 # `core.autocrlf=true` setting that would otherwise convert to CRLF
 # on checkout). BOM-free UTF-8 encoding is enforced separately by
-# .editorconfig's global `charset = utf-8` — .gitattributes can only
-# control EOL, not byte-order marks. LF is required for the
+# .editorconfig's global `charset = utf-8` — `.gitattributes` can
+# normalize line endings (and control text/binary, diff, and merge
+# behavior) but has no attribute for byte-order marks. LF is required
+# for the
 # `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
 # parses CR as part of the interpreter name (looking for `pwsh\r`),
 # and a UTF-8 BOM before `#!` would prevent shebang recognition


### PR DESCRIPTION
## Summary
The PowerShell-scripts comment in `.gitattributes` said:

> `.gitattributes` can only control EOL, not byte-order marks.

That's overly narrow — `.gitattributes` also controls text/binary normalization, diff drivers, merge drivers, `working-tree-encoding`, etc. The actual point we're making is that it has no *BOM-specific* attribute, so `.editorconfig`'s `charset = utf-8` has to handle BOM-freeness.

Reword to acknowledge the broader scope while keeping the contrast with `.editorconfig`:

```diff
 # on checkout). BOM-free UTF-8 encoding is enforced separately by
-# .editorconfig's global `charset = utf-8` — .gitattributes can only
-# control EOL, not byte-order marks. LF is required for the
+# .editorconfig's global `charset = utf-8` — `.gitattributes` can
+# normalize line endings (and control text/binary, diff, and merge
+# behavior) but has no attribute for byte-order marks. LF is required
+# for the
```

Surfaced by Copilot review on [Chris-Wolfgang/DbContextBuilder#198](https://github.com/Chris-Wolfgang/DbContextBuilder/pull/198) (the post-canonical-sync follow-up to [#196](https://github.com/Chris-Wolfgang/DbContextBuilder/pull/196)).

## Downstream
Once this lands, DbContextBuilder#198 will re-sync from the corrected canonical. Other consumer repos pick it up on their next canonical-sync cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)