### PR TITLE
chore(.gitignore): ignore docfx_project/api/*.yml (auto-generated metadata)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -430,4 +430,10 @@ nuget-packages/
 # DocFX generated files (any depth)
 _site/
 docfx_project/obj/
+# Auto-generated API metadata: `docfx metadata` writes <Type>.yml and toc.yml
+# under docfx_project/api/ for every public type extracted from src/. Keep
+# these out of the repo so a careless `git add -A` after running docfx
+# metadata locally doesn't commit generated files. The hand-written
+# index.md and README.md in api/ are intentionally tracked.
+docfx_project/api/*.yml
 


### PR DESCRIPTION
## Summary
Add `docfx_project/api/*.yml` to canonical `.gitignore` so the auto-generated metadata files from `docfx metadata` never accidentally get committed.

## Background
Caught while reviewing what to backport from [Try-Pattern PR #108](https://github.com/Chris-Wolfgang/Try-Pattern/pull/108) (which untracked a poison-pill `_site/.gitignore` that had been silently breaking gh-pages deploys).

`docfx metadata` writes per-type yml files (`Foo.yml`, `Foo.Bar.yml`, etc.) plus a `toc.yml` under `docfx_project/api/`. None of these should be tracked — they're generated fresh on every CI build. Today canonical's `.gitignore` doesn't catch them.

## Why this is defensive
Try-Pattern had committed those generated yml files in an early revision before the rule existed, then later added a per-directory `docfx_project/api/.gitignore` (`*.yml`) to scope-ignore them locally. **That defensive `.gitignore` later got copied into the `gh-pages` worktree by the docfx deploy step and acted as a poison pill (`* !.gitignore`), blocking all subsequent deploys** — root cause of Try-Pattern's broken docs site (PR #108 cleanup).

Canonical already catches `_site/` everywhere (preventing that specific poison-pill route). Adding `docfx_project/api/*.yml` to the canonical `.gitignore` prevents the adjacent class of bug — accidentally tracking generated metadata — without needing a per-directory `.gitignore` (which would itself be a copy-target for the same poison pattern).

## Files
- `.gitignore` (+6 lines, just under the existing `# DocFX generated files` section)

## Verification
```
$ git check-ignore -v docfx_project/api/Wolfgang.Foo.yml
.gitignore:438:docfx_project/api/*.yml  docfx_project/api/Wolfgang.Foo.yml
$ git check-ignore -v docfx_project/api/toc.yml
.gitignore:438:docfx_project/api/*.yml  docfx_project/api/toc.yml
$ git check-ignore -v docfx_project/api/index.md
(no output - not ignored - correct, hand-written file)
$ git check-ignore -v docfx_project/api/README.md
(no output - not ignored - correct, hand-written file)
```

## Cascade
Future downstream sync PRs will pick this up. Existing repos with already-tracked `api/*.yml` files (like Try-Pattern, which had `Wolfgang.TryPattern.*.yml` tracked at one point) won't be affected — gitignore doesn't apply to already-tracked files until they're explicitly removed.