### PR TITLE
fix(.gitattributes): reflow stranded sentence fragment in *.ps1 comment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,12 +15,13 @@
 # on checkout). BOM-free UTF-8 encoding is enforced separately by
 # .editorconfig's global `charset = utf-8` — `.gitattributes` can
 # normalize line endings (and control text/binary, diff, and merge
-# behavior) but has no attribute for byte-order marks. LF is required
-# for the
-# `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
-# parses CR as part of the interpreter name (looking for `pwsh\r`),
-# and a UTF-8 BOM before `#!` would prevent shebang recognition
-# entirely. Modern PowerShell 7+ handles LF on Windows transparently.
+# behavior) but has no attribute for byte-order marks.
+#
+# LF is required for the `#!/usr/bin/env pwsh` shebang to work on
+# Linux/macOS — the kernel parses CR as part of the interpreter name
+# (looking for `pwsh\r`), and a UTF-8 BOM before `#!` would prevent
+# shebang recognition entirely. Modern PowerShell 7+ handles LF on
+# Windows transparently.
 *.ps1 text eol=lf
 
 


### PR DESCRIPTION
## Summary
Old text had `LF is required\n# for the\n# #!/usr/bin/env pwsh` — the sentence broke across lines with "for the" stranded on its own line. Reflowed: split into two paragraphs (BOM/encoding facts, then shebang facts) so each line is a complete clause.

Caught by Copilot review on a downstream sync ([Try-Pattern PR #112](https://github.com/Chris-Wolfgang/Try-Pattern/pull/112)).

## Note about the protected-files guard
This PR touches `.gitattributes` (a protected file). The `Detect .NET Projects` guard will block — maintainer override required.