### PR TITLE
.editorconfig: clarify ps1 shebang claim to 'where present'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,9 +27,9 @@ indent_size = 2
 
 # PowerShell scripts inherit LF + UTF-8 (no BOM) + 4-space indent from
 # the global [*] section above — no per-language override is needed.
-# LF + no-BOM is required for the `#!/usr/bin/env pwsh` shebang at the
-# top of every script in scripts/ to work on Linux/macOS — CR breaks
-# the kernel's exec lookup, and a leading BOM prevents shebang
+# LF + no-BOM is required for the `#!/usr/bin/env pwsh` shebang (where
+# present) on scripts under scripts/ to work on Linux/macOS — CR
+# breaks the kernel's exec lookup, and a leading BOM prevents shebang
 # recognition entirely.
 
 # C# files


### PR DESCRIPTION
## Summary
Tightens one line in the canonical `.editorconfig` PowerShell comment so it doesn't claim the `#!/usr/bin/env pwsh` shebang is at the top of **every** script in `scripts/`. At least `scripts/Setup-Labels.ps1` starts with a `<#`-style comment block rather than the shebang, so the broader claim is false.

## Why
Copilot caught this on the downstream `chore: sync *.ps1 EOL fix from canonical` sync PRs (across 15+ repos). Fixing it here keeps the canonical and the downstream branches' tightened wording in sync — without this, the next round of syncs would re-introduce the inaccurate phrasing.

## Change
| Before | After |
|---|---|
| ``the `#!/usr/bin/env pwsh` shebang at the top of every script in scripts/`` | ``the `#!/usr/bin/env pwsh` shebang (where present) on scripts under scripts/`` |

No semantic change to the LF + no-BOM requirement itself — only the false universal claim is replaced.

## Test plan
- [ ] No further action needed in downstream repos — they were already updated with this wording directly.