### PR TITLE
docs: address Copilot review nits from downstream sync PRs

### DIFF
--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -4,7 +4,7 @@ This repository uses `dotnet format` to enforce consistent C# code style.
 
 ## Prerequisites
 
-The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 and later. Any .NET 6+ SDK on PATH is sufficient to run formatting — no separate tool installation is needed. See the workflow files and root `README.md` for the full set of SDKs used to build and test this project's target frameworks.
+The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 — no separate tool installation is needed. In practice `dotnet format` still has to load and evaluate the project, so you need an SDK new enough to handle this repo's target frameworks: use the SDK version(s) installed by `.github/workflows/pr.yaml` (and `global.json` if present). The latest stable .NET SDK is generally a safe choice.
 
 > **Note:** The standalone `dotnet-format` global tool was deprecated when `dotnet format` was integrated into the .NET 6 SDK in August 2021.
 

--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -4,7 +4,7 @@ This repository uses `dotnet format` to enforce consistent C# code style.
 
 ## Prerequisites
 
-The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 and later. Since this project requires .NET 8.0 SDK or later, you already have `dotnet format` available — no separate tool installation is needed.
+The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 and later. Any .NET 6+ SDK on PATH is sufficient to run formatting — no separate tool installation is needed. See the workflow files and root `README.md` for the full set of SDKs used to build and test this project's target frameworks.
 
 > **Note:** The standalone `dotnet-format` global tool was deprecated when `dotnet format` was integrated into the .NET 6 SDK in August 2021.
 

--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -212,7 +212,7 @@ Before creating a production GitHub Release (e.g., `v1.0.0`):
 
 If you encounter issues not covered in this guide:
 
-1. Check the [Actions tab](../../actions) for detailed logs
+1. Check the Actions tab of this repository on GitHub for detailed logs
 2. Review artifacts uploaded by failed jobs
 3. Consult the [GitHub Actions documentation](https://docs.github.com/en/actions)
 4. Open an issue in this repository with:

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -62,6 +62,8 @@ In addition to the overwrite step, a separate "Detect protected configuration fi
       "BannedSymbols.txt"
       "*.globalconfig"
       "*.ruleset"
+      ".github/workflows/*.yml"
+      ".github/workflows/*.yaml"
     )
     
     # Copy each configuration file from main branch if it exists

--- a/scripts/format.ps1
+++ b/scripts/format.ps1
@@ -38,9 +38,11 @@ if ($LASTEXITCODE -ne 0)
     Write-Host "❌ dotnet format is not available!" -ForegroundColor Red
     Write-Host ""
     Write-Host "The 'dotnet format' command is built into the .NET SDK starting with .NET 6." -ForegroundColor Yellow
-    Write-Host "This project requires .NET 8.0 SDK or later." -ForegroundColor Yellow
+    Write-Host "You need an SDK new enough to load this repo's target frameworks — see" -ForegroundColor Yellow
+    Write-Host ".github/workflows/pr.yaml (and global.json if present) for the SDK" -ForegroundColor Yellow
+    Write-Host "versions CI uses. The latest stable .NET SDK is generally a safe choice." -ForegroundColor Yellow
     Write-Host ""
-    Write-Host "Please install the .NET 8.0 SDK or later from:" -ForegroundColor Yellow
+    Write-Host "Install the .NET SDK from:" -ForegroundColor Yellow
     Write-Host "https://dotnet.microsoft.com/download" -ForegroundColor Cyan
     Write-Host ""
     exit 1


### PR DESCRIPTION
## Summary
Brings the canonical `/docs` set in line with the per-repo fixes already pushed to the downstream `chore: sync canonical /docs reference set` PRs ([IComparable-Extensions#79](https://github.com/Chris-Wolfgang/IComparable-Extensions/pull/79), [In-memory-Logger#53](https://github.com/Chris-Wolfgang/In-memory-Logger/pull/53), [ICollection-Extensions#78](https://github.com/Chris-Wolfgang/ICollection-Extensions/pull/78)). Without this, the same Copilot comments will re-fire on every future sync wave.

## Changes

### `docs/RELEASE-WORKFLOW-SETUP.md`
Replace the broken `[Actions tab](../../actions)` relative link with plain text. From inside `docs/`, GitHub resolves the relative path to `blob/<ref>/actions` (a 404), not the repository Actions tab.

### `docs/README-FORMATTING.md`
Drop the claim *"this project requires .NET 8.0 SDK or later"* — `dotnet format` is built into any .NET 6+ SDK, and consumer repos target a wide range of TFMs (net462 through net10.0). Refer readers to the workflow/README for the actual SDKs.

### `docs/WORKFLOW_SECURITY.md`
Add the missing `.github/workflows/*.yml` / `*.yaml` patterns to the `config_files` example so the snippet matches the actual fetch step in `pr.yaml`. Without them, someone copying the array as authoritative would silently stop protecting workflow files.

## Test plan
- [ ] Visual inspection of the three doc files in the GitHub UI
- [ ] No follow-up needed in downstream repos — they already carry the same fixes directly.