### PR TITLE
docfx: preserve dev/ on gh-pages so benchmark chart survives releases

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -322,9 +322,11 @@ jobs:
               git -C $WORK_DIR remote add origin "https://github.com/$($env:GITHUB_REPOSITORY).git"
             }
 
-            # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME
+            # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME, dev
+            # ('dev' is where benchmark-action/github-action-benchmark stores its
+            # chart + accumulated data.js — wiping it loses chart history on every release.)
             Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
-              $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions')
+              $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions', 'dev')
             } | Remove-Item -Recurse -Force
 
             # Ensure .nojekyll exists so GitHub Pages does not run Jekyll


### PR DESCRIPTION
## Summary
The DocFX deploy step's stale-file cleanup at the gh-pages root keeps only \`.git\`, \`CNAME\`, \`.nojekyll\`, and \`versions/\`. Everything else is deleted — including \`dev/\`, which is where [\`benchmark-action/github-action-benchmark\`](https://github.com/benchmark-action/github-action-benchmark) stores \`data.js\` (the accumulated chart history) and its rendered chart at \`/dev/bench/\`.

Result: every release silently wipes the benchmark chart, leaving only the single data point from the next post-release benchmark run. Observed in [Chris-Wolfgang/ETL-FixedWidth](https://github.com/Chris-Wolfgang/ETL-FixedWidth) where \`v0.2.1\`'s release reduced the chart from 5 entries to 1.

Add \`'dev'\` to the preserve list.

## Affected repos
Any Wolfgang.* repo that has (or will have) a benchmarks workflow following the ETL-FixedWidth pattern. Today only ETL-FixedWidth qualifies; the fix applies pre-emptively to every other repo as the same pattern propagates.

A matching local fix landed in [Chris-Wolfgang/ETL-FixedWidth#93](https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/93) to avoid wiping its next release before this canonical PR syncs.

## Test plan
- [x] One-line preserve-list change.
- [ ] CI green on this PR.
- [ ] After merge + downstream re-sync, confirm \`gh-pages:/dev/bench/data.js\` retains entries across releases.