### PR TITLE
feat(quality): introduce per-repo Quality tracking framework

### DIFF
--- a/.github/ISSUE_TEMPLATE/quality-task.yaml
+++ b/.github/ISSUE_TEMPLATE/quality-task.yaml
@@ -9,7 +9,7 @@ body:
       value: |
         ## Quality framework sub-issue
 
-        This template creates a **`quality-task`** sub-issue under this repo's parent `Quality: <repo>` issue. The new issue will auto-appear in the cross-repo [Quality project board](https://github.com/users/Chris-Wolfgang/projects).
+        This template creates a **`quality-task`** sub-issue under this repo's parent `Quality: <repo>` issue. The new issue will auto-appear in the cross-repo Quality project board (URL listed in the parent `Quality: <repo>` issue body).
 
         - Pick exactly **one** category in the dropdown below. The corresponding `quality:<category>` label will need to be added manually after creation (issue forms don't yet support dynamic label addition).
         - Fill in **Scope** (what's done & why), **Acceptance** (when do we close this?), and **Links** (PRs, scan output, related issues).

--- a/.github/ISSUE_TEMPLATE/quality-task.yaml
+++ b/.github/ISSUE_TEMPLATE/quality-task.yaml
@@ -1,0 +1,76 @@
+name: "✨ Quality task"
+description: "Track an actionable improvement under the Quality framework (security, performance, testing, cleanup, docs, api, or cicd)."
+title: "[Quality] <category>: <short description>"
+labels: [quality-task]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Quality framework sub-issue
+
+        This template creates a **`quality-task`** sub-issue under this repo's parent `Quality: <repo>` issue. The new issue will auto-appear in the cross-repo [Quality project board](https://github.com/users/Chris-Wolfgang/projects).
+
+        - Pick exactly **one** category in the dropdown below. The corresponding `quality:<category>` label will need to be added manually after creation (issue forms don't yet support dynamic label addition).
+        - Fill in **Scope** (what's done & why), **Acceptance** (when do we close this?), and **Links** (PRs, scan output, related issues).
+        - If you're closing this issue via a PR, include `Fixes #<this-issue-number>` in the PR body so the auto-add workflow marks the project item as Done.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: "Pick exactly one. After creation, also add the corresponding `quality:<category>` label."
+      options:
+        - "security — scans, finding fixes, dependency vulnerability audit"
+        - "performance — profile, benchmark, optimize, validate gains"
+        - "testing — coverage, integration/smoke/mutation tests, fixtures"
+        - "cleanup — refactor for reuse / quality / efficiency"
+        - "docs — XML doc coverage, README, CHANGELOG, samples"
+        - "api — public/internal surface audit, breaking-change vigilance"
+        - "cicd — Docker, CI workflow, build/publish pipeline"
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: "What needs to be done? What's the motivation?"
+      placeholder: |
+        e.g.
+        - Profile the hot path in `Extractor.ExtractAsync` and identify the dominant allocations.
+        - Goal: reduce per-record allocations to enable streaming larger inputs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: "When do we close this issue? Concrete observable outcomes."
+      placeholder: |
+        e.g.
+        - Benchmark X shows <50% of current allocations.
+        - No regression in existing benchmark suite (>5%).
+        - Updated benchmark numbers committed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: "Related PRs, scan output, prior issues, external references."
+      placeholder: |
+        - Related PR: #...
+        - Scan output: ...
+        - Related issue: #...
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        💡 **Tip for agents (Copilot etc.):** When opening a quality-task sub-issue, use this template and pick the matching category. After creation, add the `quality:<category>` label manually. See `.github/copilot-instructions.md` for the full Quality framework convention.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -193,7 +193,7 @@ This produces a paper trail that ties findings → tracked work → PRs, and rol
 
 When a new repo is created from this template:
 1. Run `scripts/Setup-Labels.ps1` to provision the 9 Quality labels.
-2. Run `scripts/Setup-QualityRoadmap.ps1 -QualityProjectUrl '<url>'` to create the parent Quality issue. (Pass the cross-repo project URL — ask the user if you don't have it.)
+2. Run `scripts/Setup-Quality.ps1 -QualityProjectUrl '<url>'` to create the parent Quality issue. (Pass the cross-repo project URL — ask the user if you don't have it.)
 3. The auto-add workflow in the Quality project will pick up new `quality-task` sub-issues automatically.
 
 ## Agent Guidelines

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -155,6 +155,47 @@ Branch protection rules are configured by running the local PowerShell script `s
 - `examples/` - Example usage projects
 - `docs/` - Documentation (contains placeholder `index.html`)
 
+## Quality Framework
+
+Every repo derived from this template uses a per-repo **Quality** tracking framework to organize ongoing improvement work (security, performance, testing, cleanup, docs, api, cicd). The framework has three pieces:
+
+1. **One parent `Quality: <repo>` issue per repo** (labeled `quality`). Living "improvement menu" — stays open forever. Lists candidate work by category. Never close.
+2. **Sub-issues labeled `quality-task` + a `quality:<category>` label.** These are the actual tracked work. Spawn lazily — create one when there's actionable work, close when done.
+3. **A cross-repo GitHub Projects v2 board** that auto-aggregates every `quality-task` issue across all repos for filtered views (by repo, by category, by status).
+
+### Categories (one per sub-issue)
+
+| Label | Covers |
+|---|---|
+| `quality:security` | SAST/analyzer scans, finding fixes, dependency vulnerability audit |
+| `quality:performance` | Profile, benchmark, optimize, validate gains |
+| `quality:testing` | Coverage %, integration/smoke/mutation tests, fixtures, CI test-step additions |
+| `quality:cleanup` | Refactor for reuse, quality, efficiency |
+| `quality:docs` | XML doc coverage, README, CHANGELOG, samples |
+| `quality:api` | Public/internal surface audit, breaking-change vigilance |
+| `quality:cicd` | Docker, CI workflow, build/publish pipeline, packaging |
+
+### For Copilot agents working in this repo
+
+When you **discover work** that fits one of the categories — a security scanner finding, a slow hot path, missing test coverage, code smelling for refactor, outdated docs, an inadvertent breaking API change, a flaky CI step — **don't just comment or fix it silently.** Instead:
+
+1. Open a `quality-task` sub-issue using the **"Quality task" issue template** (`.github/ISSUE_TEMPLATE/quality-task.yaml`).
+2. Pick the matching category in the dropdown.
+3. Fill in the Scope and Acceptance fields with concrete observable outcomes.
+4. After creation, add the corresponding `quality:<category>` label (the form pre-fills only `quality-task`; the category must be added manually).
+5. If you're submitting a PR that addresses the issue, include `Fixes #<sub-issue-number>` in the PR body so the project board auto-marks the item as Done.
+
+This produces a paper trail that ties findings → tracked work → PRs, and rolls up into the cross-repo Quality view so unfinished improvements aren't forgotten when the agent session ends.
+
+**Reserve plain (non-`quality:` prefixed) issues for repo-specific decisions** that aren't part of the fleet-wide pattern — e.g., "Drop net6.0 from TFM matrix," "Add new feature X," one-off bug fixes.
+
+### Provisioning Quality on a new repo
+
+When a new repo is created from this template:
+1. Run `scripts/Setup-Labels.ps1` to provision the 9 Quality labels.
+2. Run `scripts/Setup-QualityRoadmap.ps1 -QualityProjectUrl '<url>'` to create the parent Quality issue. (Pass the cross-repo project URL — ask the user if you don't have it.)
+3. The auto-add workflow in the Quality project will pick up new `quality-task` sub-issues automatically.
+
 ## Agent Guidelines
 
 ### Trust These Instructions
@@ -167,6 +208,7 @@ This information has been validated against the template structure and GitHub wo
 4. **Testing**: Ensure test projects follow `*Test*.csproj` naming convention
 5. **Coverage**: Aim for >90% code coverage to pass CI
 6. **Security**: Review DevSkim findings and address security concerns
+7. **Quality framework**: When you find improvement work that fits a category, open a `quality-task` sub-issue rather than fixing silently (see "Quality Framework" section above)
 
 ### Validation Steps
 Before submitting changes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,18 @@
 
 Fixes/Complete # (issue)
 
+<!--
+If this PR addresses a Quality framework sub-issue, link it explicitly so the
+project board auto-marks the item as Done on merge:
+
+  Fixes #<quality-task-issue-number>
+
+The Quality framework tracks ongoing improvement work (security, performance,
+testing, cleanup, docs, api, cicd) — see the parent `Quality: <repo>` issue
+for details.
+-->
+
+
 ## Type of change
 
 Please delete options that are not relevant.

--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -139,7 +139,7 @@ The Quality framework tracks ongoing, non-feature improvement work — security 
 After running `Setup-Labels.ps1`, run:
 
 ```powershell
-pwsh -File ./scripts/Setup-QualityRoadmap.ps1 -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/N'
+pwsh -File ./scripts/Setup-Quality.ps1 -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/N'
 ```
 
 Substitute the actual Quality project URL — ask the repo owner if you don't have it. The script is idempotent: running it twice will not duplicate the parent issue.

--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -104,14 +104,51 @@ Run the label setup script once after creating your repository:
 pwsh -File ./scripts/Setup-Labels.ps1
 ```
 
-This creates the following labels used by Dependabot and workflows:
+This creates the following labels:
 
+**Dependabot / dependencies:**
 1. `dependabot - security`
 2. `dependabot-dependencies`
 3. `dependencies`
 4. `dotnet`
 
+**Quality framework** (per-repo improvement tracking):
+5. `quality` — the per-repo parent Quality issue
+6. `quality-task` — actionable Quality sub-issues
+7. `quality:security` — scans, finding fixes, dependency vulnerability audit
+8. `quality:performance` — profile, benchmark, optimize, validate gains
+9. `quality:testing` — coverage, integration/smoke/mutation tests, fixtures
+10. `quality:cleanup` — refactor for reuse, quality, efficiency
+11. `quality:docs` — XML doc coverage, README, CHANGELOG, samples
+12. `quality:api` — public/internal surface audit, breaking-change vigilance
+13. `quality:cicd` — Docker, CI workflow, build/publish pipeline
+
 Requires the [GitHub CLI](https://cli.github.com/) to be installed and authenticated (`gh auth login`).
+
+
+## Set Up the Quality Framework
+
+The Quality framework tracks ongoing, non-feature improvement work — security scanning, performance review, test coverage, cleanup, etc. — across all repos. It has three pieces:
+
+1. **Per-repo parent issue** titled `Quality: <repo>` (labeled `quality`). This is a living "improvement menu" — stays open forever. Lists candidate work organized by category.
+2. **Sub-issues** labeled `quality-task` plus one category label (e.g., `quality:security`). Created lazily when actual work begins; closed when complete.
+3. **Cross-repo Projects v2 board** that auto-aggregates every `quality-task` issue across all repos. Provides Table, Board, and (optional) Roadmap views.
+
+### Create the parent Quality issue
+
+After running `Setup-Labels.ps1`, run:
+
+```powershell
+pwsh -File ./scripts/Setup-QualityRoadmap.ps1 -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/N'
+```
+
+Substitute the actual Quality project URL — ask the repo owner if you don't have it. The script is idempotent: running it twice will not duplicate the parent issue.
+
+### Sub-issues are created lazily
+
+Don't pre-create one issue per category. Sub-issues only get created when there's actionable work — e.g., when a scan finds something, a profile identifies a hot path, or a coverage gap is noticed. Use the **"Quality task"** issue template (`.github/ISSUE_TEMPLATE/quality-task.yaml`) when creating one — it pre-fills the right labels and prompts for scope and acceptance.
+
+Repo-specific decisions that don't fit the fleet-wide pattern (a TFM drop, a one-off bug fix, a feature request) are tracked as **regular issues without the `quality:` prefix** so they stay out of the Quality project board.
 
 
 ## Creating the project

--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -146,7 +146,7 @@ Substitute the actual Quality project URL — ask the repo owner if you don't ha
 
 ### Sub-issues are created lazily
 
-Don't pre-create one issue per category. Sub-issues only get created when there's actionable work — e.g., when a scan finds something, a profile identifies a hot path, or a coverage gap is noticed. Use the **"Quality task"** issue template (`.github/ISSUE_TEMPLATE/quality-task.yaml`) when creating one — it pre-fills the right labels and prompts for scope and acceptance.
+Don't pre-create one issue per category. Sub-issues only get created when there's actionable work — e.g., when a scan finds something, a profile identifies a hot path, or a coverage gap is noticed. Use the **"Quality task"** issue template (`.github/ISSUE_TEMPLATE/quality-task.yaml`) when creating one — it pre-fills the `quality-task` label and prompts for category, scope, and acceptance. After creation, **manually add the matching `quality:<category>` label** (issue forms can't apply labels dynamically based on dropdown selections yet).
 
 Repo-specific decisions that don't fit the fleet-wide pattern (a TFM drop, a one-off bug fix, a feature request) are tracked as **regular issues without the `quality:` prefix** so they stay out of the Quality project board.
 

--- a/scripts/Setup-Labels.ps1
+++ b/scripts/Setup-Labels.ps1
@@ -8,10 +8,19 @@
     other workflows. Run this locally once after creating a new repo from the template.
     
     Labels created:
-    - dependabot - security  (red)
-    - dependabot-dependencies (orange)
-    - dependencies           (blue)
-    - dotnet                 (purple)
+    - dependabot - security    (red)
+    - dependabot-dependencies  (orange)
+    - dependencies             (blue)
+    - dotnet                   (purple)
+    - quality                  (purple)     — kind label, applied to the per-repo parent Quality issue
+    - quality-task             (blue)       — kind label, applied to every Quality sub-issue
+    - quality:security         (red)        — category: scans, finding fixes, dependency vuln audit
+    - quality:performance      (orange)     — category: profile, benchmark, optimize, validate
+    - quality:testing          (green)      — category: coverage, integration/smoke/mutation tests
+    - quality:cleanup          (yellow)     — category: refactor for reuse / quality / efficiency
+    - quality:docs             (teal)       — category: XML docs, README, CHANGELOG, samples
+    - quality:api              (light purple) — category: public/internal surface audit
+    - quality:cicd             (deep purple)  — category: Docker, CI workflow, build/publish pipeline
 
 .PARAMETER Repository
     The repository in owner/repo format. If not provided, uses the current repository.
@@ -75,10 +84,24 @@ if (-not $Repository) {
 Write-Host "`n🏷️  Creating labels for: $Repository`n" -ForegroundColor Cyan
 
 $labels = @(
+    # Dependabot / dependencies
     @{ name = "dependabot - security";    color = "b60205"; description = "Security update from Dependabot" },
     @{ name = "dependabot-dependencies";  color = "d93f0b"; description = "Dependency update from Dependabot" },
     @{ name = "dependencies";             color = "0366d6"; description = "Pull requests that update a dependency file" },
-    @{ name = "dotnet";                   color = "512bd4"; description = ".NET related changes" }
+    @{ name = "dotnet";                   color = "512bd4"; description = ".NET related changes" },
+
+    # Quality framework — kind labels
+    @{ name = "quality";                  color = "6f42c1"; description = "Per-repo parent Quality issue (living improvement menu)" },
+    @{ name = "quality-task";             color = "1d76db"; description = "A Quality sub-issue — actionable improvement work" },
+
+    # Quality framework — category labels (applied to sub-issues)
+    @{ name = "quality:security";         color = "b60205"; description = "Quality: scans, finding fixes, dependency vulnerability audit" },
+    @{ name = "quality:performance";      color = "d93f0b"; description = "Quality: profile, benchmark, optimize, validate gains" },
+    @{ name = "quality:testing";          color = "0e8a16"; description = "Quality: coverage %, integration/smoke/mutation tests, fixtures" },
+    @{ name = "quality:cleanup";          color = "fbca04"; description = "Quality: refactor for reuse, quality, efficiency" },
+    @{ name = "quality:docs";             color = "006b75"; description = "Quality: XML doc coverage, README, CHANGELOG, samples" },
+    @{ name = "quality:api";              color = "d4c5f9"; description = "Quality: public/internal surface audit, breaking-change vigilance" },
+    @{ name = "quality:cicd";             color = "5319e7"; description = "Quality: Docker, CI workflow, build/publish pipeline" }
 )
 
 $created = 0

--- a/scripts/Setup-Quality.ps1
+++ b/scripts/Setup-Quality.ps1
@@ -88,17 +88,24 @@ $issueTitle = "Quality: $repoName"
 # the check to miss the actual parent and create a duplicate. After fetching,
 # filter to exact title match.
 Write-Host "`n🔍 Checking for existing parent Quality issue..." -ForegroundColor Cyan
-$existing = gh issue list `
-    --repo $Repository `
-    --label 'quality' `
-    --state all `
-    --json number,title,state `
-    --limit 1000 2>&1
+# Capture stdout and stderr separately so JSON parsing isn't corrupted by
+# any warnings gh emits to stderr. Only stdout is fed to ConvertFrom-Json.
+$stderrFile = Join-Path ([IO.Path]::GetTempPath()) "setup-quality-stderr-$([guid]::NewGuid()).txt"
+try {
+    $existing = gh issue list `
+        --repo $Repository `
+        --label 'quality' `
+        --state all `
+        --json number,title,state `
+        --limit 1000 2> $stderrFile
 
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "❌ Failed to query existing issues. Verify the 'quality' label exists in $Repository (run Setup-Labels.ps1 first)."
-    Write-Host $existing -ForegroundColor Red
-    exit 1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "❌ Failed to query existing issues. Verify the 'quality' label exists in $Repository (run Setup-Labels.ps1 first)."
+        if (Test-Path $stderrFile) { Write-Host (Get-Content $stderrFile -Raw) -ForegroundColor Red }
+        exit 1
+    }
+} finally {
+    Remove-Item -Path $stderrFile -ErrorAction SilentlyContinue
 }
 
 $matches = $existing | ConvertFrom-Json | Where-Object { $_.title -eq $issueTitle }
@@ -121,9 +128,10 @@ if (-not (Test-Path $templatePath)) {
 
 $body = Get-Content -Path $templatePath -Raw
 
-# Substitute placeholders
-$body = $body -replace '\{\{QUALITY_PROJECT_URL\}\}', $QualityProjectUrl
-$body = $body -replace '\{\{REPO_NAME\}\}', $repoName
+# Literal string replacement (.Replace) rather than -replace, since
+# -replace's right-hand-side honors regex tokens like '$' and we don't want
+# to alter the URL the caller passed in.
+$body = $body.Replace('{{QUALITY_PROJECT_URL}}', $QualityProjectUrl)
 
 # Write body to a temp file to avoid command-line length / quoting issues.
 # Use [IO.Path]::GetTempPath() so this works on Linux/macOS (where $env:TEMP

--- a/scripts/Setup-Quality.ps1
+++ b/scripts/Setup-Quality.ps1
@@ -83,15 +83,17 @@ if (-not $Repository) {
 $repoName = ($Repository -split '/')[-1]
 $issueTitle = "Quality: $repoName"
 
-# Idempotency: check if a parent Quality issue already exists
+# Idempotency: check if a parent Quality issue already exists.
+# Limit is large (1000) so accidental over-use of the `quality` label can't cause
+# the check to miss the actual parent and create a duplicate. After fetching,
+# filter to exact title match.
 Write-Host "`n🔍 Checking for existing parent Quality issue..." -ForegroundColor Cyan
 $existing = gh issue list `
     --repo $Repository `
     --label 'quality' `
     --state all `
-    --search "in:title `"Quality: $repoName`"" `
     --json number,title,state `
-    --limit 5 2>&1
+    --limit 1000 2>&1
 
 if ($LASTEXITCODE -ne 0) {
     Write-Error "❌ Failed to query existing issues. Verify the 'quality' label exists in $Repository (run Setup-Labels.ps1 first)."
@@ -123,8 +125,10 @@ $body = Get-Content -Path $templatePath -Raw
 $body = $body -replace '\{\{QUALITY_PROJECT_URL\}\}', $QualityProjectUrl
 $body = $body -replace '\{\{REPO_NAME\}\}', $repoName
 
-# Write body to a temp file to avoid command-line length / quoting issues
-$bodyFile = Join-Path $env:TEMP "quality-parent-body-$([guid]::NewGuid()).md"
+# Write body to a temp file to avoid command-line length / quoting issues.
+# Use [IO.Path]::GetTempPath() so this works on Linux/macOS (where $env:TEMP
+# can be unset) as well as Windows.
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) "quality-parent-body-$([guid]::NewGuid()).md"
 Set-Content -Path $bodyFile -Value $body -Encoding utf8NoBOM
 
 try {

--- a/scripts/Setup-Quality.ps1
+++ b/scripts/Setup-Quality.ps1
@@ -24,11 +24,11 @@
     https://github.com/users/Chris-Wolfgang/projects/N). Substituted into the issue body.
 
 .EXAMPLE
-    .\Setup-QualityRoadmap.ps1 -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/5'
+    .\Setup-Quality.ps1 -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/5'
     Creates the parent Quality issue for the current repository.
 
 .EXAMPLE
-    .\Setup-QualityRoadmap.ps1 -Repository 'Chris-Wolfgang/my-repo' -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/5'
+    .\Setup-Quality.ps1 -Repository 'Chris-Wolfgang/my-repo' -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/5'
     Creates the parent Quality issue for a specific repository.
 
 .NOTES

--- a/scripts/Setup-QualityRoadmap.ps1
+++ b/scripts/Setup-QualityRoadmap.ps1
@@ -1,0 +1,147 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Creates the per-repo parent "Quality" issue that anchors the Quality framework.
+
+.DESCRIPTION
+    The Quality framework tracks ongoing improvement work (security, performance, testing,
+    cleanup, docs, api, cicd) across all Chris-Wolfgang .NET code repos. Each repo has
+    one parent Quality issue (this script creates it) that documents candidate work by
+    category. Actual tracked work lives in sub-issues labeled `quality-task` plus a
+    `quality:<category>` label, and rolls up into a cross-repo GitHub Projects v2 board.
+
+    This script is idempotent — if a `Quality: <repo>` issue with the `quality` label
+    already exists in the target repository, the script reports it and exits 0.
+
+    Requires that the labels `quality` and `quality-task` (plus the 7 category labels)
+    already exist in the target repo. Run Setup-Labels.ps1 first.
+
+.PARAMETER Repository
+    The repository in owner/repo format. If not provided, uses the current repository.
+
+.PARAMETER QualityProjectUrl
+    The URL of the cross-repo Quality Projects v2 board (e.g.
+    https://github.com/users/Chris-Wolfgang/projects/N). Substituted into the issue body.
+
+.EXAMPLE
+    .\Setup-QualityRoadmap.ps1 -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/5'
+    Creates the parent Quality issue for the current repository.
+
+.EXAMPLE
+    .\Setup-QualityRoadmap.ps1 -Repository 'Chris-Wolfgang/my-repo' -QualityProjectUrl 'https://github.com/users/Chris-Wolfgang/projects/5'
+    Creates the parent Quality issue for a specific repository.
+
+.NOTES
+    Requires: GitHub CLI (gh) authenticated with sufficient permissions.
+    Install gh: https://cli.github.com/
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Repository,
+
+    [Parameter(Mandatory = $true)]
+    [string]$QualityProjectUrl
+)
+
+# Check gh CLI
+try {
+    $null = gh --version
+} catch {
+    Write-Error "❌ GitHub CLI (gh) is not installed or not in PATH."
+    Write-Host "Install from: https://cli.github.com/" -ForegroundColor Yellow
+    exit 1
+}
+
+try {
+    $null = gh auth status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "❌ Not authenticated with GitHub CLI."
+        Write-Host "Run: gh auth login" -ForegroundColor Yellow
+        exit 1
+    }
+} catch {
+    Write-Error "❌ Failed to check GitHub CLI authentication status."
+    exit 1
+}
+
+# Determine repository
+if (-not $Repository) {
+    Write-Host "🔍 Detecting current repository..." -ForegroundColor Cyan
+    try {
+        $repoInfo = gh repo view --json nameWithOwner | ConvertFrom-Json
+        $Repository = $repoInfo.nameWithOwner
+        Write-Host "✅ Using repository: $Repository" -ForegroundColor Green
+    } catch {
+        Write-Error "❌ Could not detect repository. Please run from within a git repository or specify -Repository parameter."
+        exit 1
+    }
+}
+
+# Repository's bare name (after the /)
+$repoName = ($Repository -split '/')[-1]
+$issueTitle = "Quality: $repoName"
+
+# Idempotency: check if a parent Quality issue already exists
+Write-Host "`n🔍 Checking for existing parent Quality issue..." -ForegroundColor Cyan
+$existing = gh issue list `
+    --repo $Repository `
+    --label 'quality' `
+    --state all `
+    --search "in:title `"Quality: $repoName`"" `
+    --json number,title,state `
+    --limit 5 2>&1
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "❌ Failed to query existing issues. Verify the 'quality' label exists in $Repository (run Setup-Labels.ps1 first)."
+    Write-Host $existing -ForegroundColor Red
+    exit 1
+}
+
+$matches = $existing | ConvertFrom-Json | Where-Object { $_.title -eq $issueTitle }
+if ($matches) {
+    $match = $matches | Select-Object -First 1
+    Write-Host "⏭️  Parent Quality issue already exists: #$($match.number) [$($match.state)]" -ForegroundColor Gray
+    Write-Host "    https://github.com/$Repository/issues/$($match.number)" -ForegroundColor Gray
+    exit 0
+}
+
+# Read canonical body template
+$scriptDir   = Split-Path -Parent $PSCommandPath
+$templatePath = Join-Path $scriptDir 'templates/quality-parent-body.md'
+
+if (-not (Test-Path $templatePath)) {
+    Write-Error "❌ Canonical body template not found at: $templatePath"
+    Write-Host "Expected the file at scripts/templates/quality-parent-body.md relative to this script." -ForegroundColor Yellow
+    exit 1
+}
+
+$body = Get-Content -Path $templatePath -Raw
+
+# Substitute placeholders
+$body = $body -replace '\{\{QUALITY_PROJECT_URL\}\}', $QualityProjectUrl
+$body = $body -replace '\{\{REPO_NAME\}\}', $repoName
+
+# Write body to a temp file to avoid command-line length / quoting issues
+$bodyFile = Join-Path $env:TEMP "quality-parent-body-$([guid]::NewGuid()).md"
+Set-Content -Path $bodyFile -Value $body -Encoding utf8NoBOM
+
+try {
+    Write-Host "`n📝 Creating parent Quality issue in $Repository..." -ForegroundColor Cyan
+    $createResult = gh issue create `
+        --repo $Repository `
+        --title $issueTitle `
+        --body-file $bodyFile `
+        --label 'quality' 2>&1
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "✅ Created: $createResult" -ForegroundColor Green
+    } else {
+        Write-Error "❌ Failed to create parent Quality issue."
+        Write-Host $createResult -ForegroundColor Red
+        exit 1
+    }
+} finally {
+    Remove-Item -Path $bodyFile -ErrorAction SilentlyContinue
+}

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1021,7 +1021,7 @@ function Start-Setup {
     Write-Host ""
     Write-Host "3. Create the parent Quality issue for this repo" -ForegroundColor Yellow
     Write-Host "   pwsh ./scripts/Setup-Quality.ps1 -QualityProjectUrl '<url>'" -ForegroundColor Gray
-    Write-Host "   # The cross-repo Quality project URL — ask for it or check repo-template's README" -ForegroundColor DarkGray
+    Write-Host "   # The cross-repo Quality project URL — ask the repo owner if you don't have it" -ForegroundColor DarkGray
     Write-Host ""
     Write-Host "4. Start developing!" -ForegroundColor Yellow
     if ($solutionName) {

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1020,7 +1020,7 @@ function Start-Setup {
     Write-Host "   pwsh ./scripts/Setup-Labels.ps1" -ForegroundColor Gray
     Write-Host ""
     Write-Host "3. Create the parent Quality issue for this repo" -ForegroundColor Yellow
-    Write-Host "   pwsh ./scripts/Setup-QualityRoadmap.ps1 -QualityProjectUrl '<url>'" -ForegroundColor Gray
+    Write-Host "   pwsh ./scripts/Setup-Quality.ps1 -QualityProjectUrl '<url>'" -ForegroundColor Gray
     Write-Host "   # The cross-repo Quality project URL — ask for it or check repo-template's README" -ForegroundColor DarkGray
     Write-Host ""
     Write-Host "4. Start developing!" -ForegroundColor Yellow

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1016,7 +1016,14 @@ function Start-Setup {
     Write-Host ""
     Write-Host "1. Configure branch protection (see REPO-INSTRUCTIONS.md if kept)" -ForegroundColor Yellow
     Write-Host ""
-    Write-Host "2. Start developing!" -ForegroundColor Yellow
+    Write-Host "2. Provision custom labels (includes the Quality framework labels)" -ForegroundColor Yellow
+    Write-Host "   pwsh ./scripts/Setup-Labels.ps1" -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "3. Create the parent Quality issue for this repo" -ForegroundColor Yellow
+    Write-Host "   pwsh ./scripts/Setup-QualityRoadmap.ps1 -QualityProjectUrl '<url>'" -ForegroundColor Gray
+    Write-Host "   # The cross-repo Quality project URL — ask for it or check repo-template's README" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "4. Start developing!" -ForegroundColor Yellow
     if ($solutionName) {
         Write-Host "   # Solution file created: $solutionName.slnx" -ForegroundColor Gray
         Write-Host "   # Add your projects to src/ and tests/" -ForegroundColor Gray

--- a/scripts/templates/quality-parent-body.md
+++ b/scripts/templates/quality-parent-body.md
@@ -1,0 +1,52 @@
+This issue is the living **improvement menu** for this repo. It is intentionally evergreen — the parent stays open forever. Sub-issues are spawned from the categories below as work begins, and they get closed when complete. The parent is never closed.
+
+## How this works
+
+- **This issue (`quality` label)** is the per-repo reference. Read it to see candidate work for this repo.
+- **Sub-issues (`quality-task` + `quality:<category>` labels)** are the actual tracked work.
+- All `quality-task` issues across all repos roll up into the Quality project board: {{QUALITY_PROJECT_URL}}
+- To create a sub-issue, use the **"Quality task"** issue template (`.github/ISSUE_TEMPLATE/quality-task.yml`). It pre-fills the right labels and prompts for scope, acceptance criteria, and links.
+
+## Candidate tasks by category
+
+### Security (`quality:security`)
+- Run SAST / analyzer scan
+- Audit dependencies for CVEs / outdated packages
+- Fix findings from scans
+
+### Performance (`quality:performance`)
+- Profile hot paths
+- Add benchmarks for identified hotspots
+- Optimize bottlenecks found via profiling / benchmarks
+- Validate performance gains via benchmark deltas
+
+### Testing (`quality:testing`)
+- Achieve / maintain code coverage ≥ 90 %
+- Add integration test suite
+- Add mutation tests (Stryker)
+- Refactor test fixtures
+- Add CI test-step improvements (e.g. coverage collectors, gates)
+
+### Cleanup (`quality:cleanup`)
+- Refactor for reuse / quality / efficiency ("simplify pass")
+- Remove dead code
+
+### Docs (`quality:docs`)
+- XML doc coverage on all public API
+- Refresh README and CHANGELOG
+- Add usage samples
+
+### API (`quality:api`)
+- Audit public vs internal surface
+- Breaking-change vigilance / API review
+
+### CI/CD (`quality:cicd`)
+- Refactor CI workflows
+- Set up Docker build (if applicable)
+- Improve packaging / publish pipeline
+
+## Notes
+
+- Not every category is relevant to every repo at every time. **Spawn sub-issues only when there is actionable work** — don't pre-fill the categories with placeholder tasks.
+- Repo-specific decisions that don't fit the fleet-wide pattern (e.g., dropping a TFM, a one-off bug fix, a feature request) are tracked as **regular issues without the `quality:` prefix**. They stay out of the Project board.
+- This issue should not be closed. If everything is "done", that just means there's no actionable work right now — but the categories remain a reference for the next cycle.

--- a/scripts/templates/quality-parent-body.md
+++ b/scripts/templates/quality-parent-body.md
@@ -5,7 +5,7 @@ This issue is the living **improvement menu** for this repo. It is intentionally
 - **This issue (`quality` label)** is the per-repo reference. Read it to see candidate work for this repo.
 - **Sub-issues (`quality-task` + `quality:<category>` labels)** are the actual tracked work.
 - All `quality-task` issues across all repos roll up into the Quality project board: {{QUALITY_PROJECT_URL}}
-- To create a sub-issue, use the **"Quality task"** issue template (`.github/ISSUE_TEMPLATE/quality-task.yaml`). It pre-fills the right labels and prompts for scope, acceptance criteria, and links.
+- To create a sub-issue, use the **"Quality task"** issue template (`.github/ISSUE_TEMPLATE/quality-task.yaml`). It pre-fills the `quality-task` label and prompts for category, scope, acceptance criteria, and links. After creation, **manually add the matching `quality:<category>` label** — issue forms can't apply labels dynamically based on dropdown selections yet.
 
 ## Candidate tasks by category
 

--- a/scripts/templates/quality-parent-body.md
+++ b/scripts/templates/quality-parent-body.md
@@ -5,7 +5,7 @@ This issue is the living **improvement menu** for this repo. It is intentionally
 - **This issue (`quality` label)** is the per-repo reference. Read it to see candidate work for this repo.
 - **Sub-issues (`quality-task` + `quality:<category>` labels)** are the actual tracked work.
 - All `quality-task` issues across all repos roll up into the Quality project board: {{QUALITY_PROJECT_URL}}
-- To create a sub-issue, use the **"Quality task"** issue template (`.github/ISSUE_TEMPLATE/quality-task.yml`). It pre-fills the right labels and prompts for scope, acceptance criteria, and links.
+- To create a sub-issue, use the **"Quality task"** issue template (`.github/ISSUE_TEMPLATE/quality-task.yaml`). It pre-fills the right labels and prompts for scope, acceptance criteria, and links.
 
 ## Candidate tasks by category
 


### PR DESCRIPTION
## Summary

Establishes the canonical machinery for the **Quality framework** — a per-repo tracking system for ongoing, non-feature improvement work (security, performance, testing, cleanup, docs, api, cicd) that spans all .NET code repos derived from this template.

The design was settled in a long discussion that lives at `C:\Users\cwolf\.claude\plans\this-is-sounding-good-pure-jellyfish.md`. Highlights:

- **One parent `Quality: <repo>` issue per repo** (label: `quality`). Living improvement menu — stays open forever, lists candidate work by category, never closes.
- **Sub-issues spawn lazily** as actual work begins. Each labeled `quality-task` + one `quality:<category>` label. Close when complete.
- **A cross-repo Projects v2 board** auto-aggregates every `quality-task` issue across all linked repos (Table, Board, optional Roadmap views).
- Reserved for **fleet-wide, recurring concerns**. Repo-specific decisions (TFM drops, one-off bugs, feature requests) use plain issues without the `quality:` prefix so they stay out of the project board.

We landed on `quality` over `roadmap` because the work is engineering hygiene, not time-boxed planning.

## What this PR changes

### New labels (in `scripts/Setup-Labels.ps1`)

| Label | Color | Covers |
|---|---|---|
| `quality` | purple | The per-repo parent Quality issue |
| `quality-task` | blue | A Quality sub-issue (actionable work) |
| `quality:security` | red | Scans, finding fixes, dependency vulnerability audit |
| `quality:performance` | orange | Profile, benchmark, optimize, validate gains |
| `quality:testing` | green | Coverage %, integration/smoke/mutation tests, fixtures |
| `quality:cleanup` | yellow | Refactor for reuse, quality, efficiency |
| `quality:docs` | teal | XML doc coverage, README, CHANGELOG, samples |
| `quality:api` | light purple | Public/internal surface audit, breaking-change vigilance |
| `quality:cicd` | deep purple | Docker, CI workflows, build/publish pipeline |

### New scripts

- **`scripts/Setup-Quality.ps1`** — creates the parent Quality issue idempotently. Reads the canonical body from `scripts/templates/quality-parent-body.md` and substitutes the project URL. Re-running on a repo that already has a parent reports the existing issue and exits 0.
- **`scripts/templates/quality-parent-body.md`** — canonical body for the parent issue. Lists candidate tasks per category and explains how the framework works.

### Updated scripts

- **`scripts/Setup-Labels.ps1`** — adds the 9 quality labels alongside the existing dependabot/dependencies labels.
- **`scripts/setup.ps1`** — `Next Steps` output now includes running `Setup-Labels.ps1` and `Setup-Quality.ps1`.

### New / updated `.github/` files

- **`.github/ISSUE_TEMPLATE/quality-task.yaml` (new)** — issue form for sub-issues. Pre-fills `quality-task` + category dropdown. Prompts for Scope, Acceptance, Links.
- **`.github/pull_request_template.md`** — adds a comment hint to link `Fixes #N` for quality-task issues (so the project board auto-marks them Done on merge).
- **`.github/copilot-instructions.md`** — full "Quality Framework" section teaching Copilot/agents to open `quality-task` sub-issues when they discover categorizable improvement work, rather than fixing silently. Includes a category table and the workflow for new repos.

### Documentation

- **`REPO-INSTRUCTIONS.md`** — new "Set Up the Quality Framework" section in the new-repo bootstrap walkthrough.

## What does NOT change in this PR

- **No labels applied to the 24 existing downstream repos.** That's a separate fan-out using the updated `Setup-Labels.ps1`.
- **No parent Quality issues created on the 24 existing downstream repos.** Separate fan-out using `Setup-Quality.ps1`.
- **No Projects v2 board created.** One-time UI step; documented but not automated.

These will land as a follow-up after this canonical change merges.

## Note about the protected-files guard

This PR touches `.github/copilot-instructions.md`, `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/quality-task.yaml`. The `Detect .NET Projects` guard will fail it. Maintainer override required — standard path for repo-template canonical changes.

## Test plan

After merge:
- Run `pwsh scripts/Setup-Labels.ps1 -Repository Chris-Wolfgang/<test-repo>` on one repo. Verify all 9 quality labels created (and 4 dependabot/dependencies labels, idempotent re-run).
- Create the cross-repo Projects v2 board manually via UI (settings, custom fields, views, auto-add workflow filter on `label:quality-task`).
- Run `pwsh scripts/Setup-Quality.ps1 -Repository Chris-Wolfgang/<test-repo> -QualityProjectUrl '<url>'`. Verify a `Quality: <repo>` issue is created with the canonical body and `quality` label.
- Re-run the same command — verify it detects the existing parent and exits 0.
- Visit the new "Quality task" issue form in the test repo — verify it pre-fills `quality-task` label and shows the category dropdown.
- Once this works on one repo, fan it out to the other 23.

