### PR TITLE
Remove the unused `dotnet` label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "dotnet"
     groups:
       dotnet-dependencies:
         patterns:

--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -106,20 +106,19 @@ pwsh -File ./scripts/Setup-Labels.ps1
 
 This creates the following labels:
 
-**Dependabot / dependencies** (Dependabot applies these automatically per `.github/dependabot.yml`):
+**Dependabot** (applied automatically per `.github/dependabot.yml`):
 1. `dependencies`
-2. `dotnet`
 
 **Maintenance framework** (per-repo improvement tracking):
-3. `maintenance` — the per-repo parent Maintenance issue
-4. `maintenance-task` — actionable Maintenance sub-issues
-5. `maintenance - security` — scans, finding fixes, dependency vulnerability audit
-6. `maintenance - performance` — profile, benchmark, optimize, validate gains
-7. `maintenance - testing` — coverage, integration/smoke/mutation tests, fixtures
-8. `maintenance - cleanup` — refactor for reuse, quality, efficiency
-9. `maintenance - docs` — XML doc coverage, README, CHANGELOG, samples
-10. `maintenance - API` — public/internal surface audit, breaking-change vigilance
-11. `maintenance - CI/CD` — Docker, CI workflow, build/publish pipeline
+2. `maintenance` — the per-repo parent Maintenance issue
+3. `maintenance-task` — actionable Maintenance sub-issues
+4. `maintenance - security` — scans, finding fixes, dependency vulnerability audit
+5. `maintenance - performance` — profile, benchmark, optimize, validate gains
+6. `maintenance - testing` — coverage, integration/smoke/mutation tests, fixtures
+7. `maintenance - cleanup` — refactor for reuse, quality, efficiency
+8. `maintenance - docs` — XML doc coverage, README, CHANGELOG, samples
+9. `maintenance - API` — public/internal surface audit, breaking-change vigilance
+10. `maintenance - CI/CD` — Docker, CI workflow, build/publish pipeline
 
 Requires the [GitHub CLI](https://cli.github.com/) to be installed and authenticated (`gh auth login`).
 

--- a/scripts/Setup-Labels.ps1
+++ b/scripts/Setup-Labels.ps1
@@ -9,7 +9,6 @@
     
     Labels created:
     - dependencies             (blue)   — applied automatically by Dependabot to every update PR
-    - dotnet                   (purple) — applied by Dependabot for NuGet ecosystem PRs
     - maintenance              (steel)  — kind label, applied to the per-repo parent Maintenance issue
     - maintenance-task         (steel)  — kind label, applied to every Maintenance sub-issue
     - maintenance - security   (red)    — category: scans, finding fixes, dependency vuln audit
@@ -82,9 +81,8 @@ if (-not $Repository) {
 Write-Host "`n🏷️  Creating labels for: $Repository`n" -ForegroundColor Cyan
 
 $labels = @(
-    # Dependabot / dependencies — Dependabot applies these automatically per .github/dependabot.yml
+    # Dependabot — applies `dependencies` automatically per .github/dependabot.yml
     @{ name = "dependencies";             color = "0366d6"; description = "Pull requests that update a dependency file" },
-    @{ name = "dotnet";                   color = "512bd4"; description = ".NET related changes" },
 
     # Maintenance framework — kind labels (neutral steel: the meta is colorless)
     @{ name = "maintenance";              color = "9aa7b3"; description = "Per-repo parent Maintenance issue (living improvement menu)" },


### PR DESCRIPTION
## Summary

Resolves the canonical-source half of #365.

The `dotnet` label was auto-applied by Dependabot to every NuGet update PR, intended to separate .NET-ecosystem updates from others. But every repo in the fleet is a .NET repo — the label carried no signal, and work is triaged by *kind* (security, bug, feature), not ecosystem.

- `.github/dependabot.yml` — drop `dotnet` from `labels:` (keep `dependencies`)
- `scripts/Setup-Labels.ps1` — drop the `dotnet` label (array entry + doc legend) so new repos don't provision it
- `REPO-INSTRUCTIONS.md` — update the label list

## Already done outside this PR

The `dotnet` label has been **deleted from all 26 active repos** (`gh label delete`, 0 failures). Dependabot does not re-create configured labels that don't exist, so the deletion is durable even before each downstream `dependabot.yml` is synced.

## Follow-up (not this PR)

Downstream repos' own `.github/dependabot.yml` still list `dotnet` — harmless (Dependabot silently skips missing labels) and will be cleaned up via the routine template-sync flow.

Closes #365.

## Test plan
- [ ] `Setup-Labels.ps1` provisions 10 labels (was 11) on a fresh repo
- [ ] Dependabot still applies `dependencies` on update PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)