### PR TITLE
Add github-actions ecosystem to Dependabot (CI2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,16 @@ updates:
       dotnet-dependencies:
         patterns:
           - "*"
+
+  # Keep third-party GitHub Actions pinned in workflows up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Canonical change for fleet maintenance initiative **CI2**.

`.github/dependabot.yml` only watched the **NuGet** ecosystem — third-party GitHub Actions pinned in workflows (`actions/checkout`, `actions/setup-dotnet`, etc.) were never getting update PRs. Adds a `github-actions` update block (weekly, grouped, labeled `dependencies`).

Downstream repos pick this up via the routine template-sync flow (initiative C1).

## Test plan
- [ ] Dependabot config validates
- [ ] After merge, Dependabot starts opening grouped `github-actions` update PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)