### PR TITLE
Enable CodeQL security-extended query pack (S1)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -80,6 +80,9 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        # security-extended adds the broader security query pack on top of the
+        # default queries (more rules, slightly longer scans).
+        queries: security-extended
 
     - name: Setup .NET
       if: steps.check-csharp.outputs.has-csharp == 'true'


### PR DESCRIPTION
## Summary

Canonical change for fleet maintenance initiative **S1**.

The CodeQL workflow ran only the **default** query suite. Adds `queries: security-extended` to the `codeql-action/init` step — the broader security query pack catches more vulnerability patterns, at the cost of slightly longer scan time.

Downstream repos pick this up via the routine template-sync flow (initiative C1).

## Note

`.github/workflows/*` is a protected path — this PR may need admin bypass to merge. It's intentionally a one-line, single-file change so it's trivial to review before bypassing.

## Test plan
- [ ] CodeQL workflow still runs green on this repo
- [ ] Scan uses the security-extended pack (visible in the Actions log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)