### PR TITLE
Run secrets-scan, detect-projects, and security-scan jobs on repo-template

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,7 +41,6 @@ jobs:
   secrets-scan:
     name: "Secrets Scan (gitleaks)"
     runs-on: ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -79,7 +78,6 @@ jobs:
   detect-projects:
     name: "Detect .NET Projects"
     runs-on: ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
     outputs:
       has-projects: ${{ steps.check-projects.outputs.has-projects }}
     
@@ -1158,7 +1156,6 @@ jobs:
   security-scan:
     name: "Security Scan (DevSkim)"
     runs-on: ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Removes the `if: github.repository != ''Chris-Wolfgang/repo-template''` guard from three jobs in `pr.yaml`:

- `secrets-scan` (Secrets Scan (gitleaks))
- `detect-projects` (Detect .NET Projects)
- `security-scan` (Security Scan (DevSkim))

The guard on the three .NET test stages (`test-linux-core`, `test-windows`, `test-macos-core`) is **left in place** — those jobs need test projects to do anything meaningful and would have nothing to do on the template.

## Why

The branch ruleset on `repo-template` requires these six job names. The previous behaviour:

1. Job''s `if:` guard fires on the template repo
2. Job is reported as `SKIPPED`
3. GitHub treats SKIPPED required checks as missing → BLOCKED merge

Result: every PR to repo-template (4 currently open: #387, #388, #390, #393) is stuck despite being mergeable on every other axis.

These three jobs **can and should** run on the template:

| Job | Why it''s valuable on the template |
|---|---|
| `secrets-scan` | A secret committed to the template propagates to every new repo created from it — higher blast radius than a downstream leak |
| `detect-projects` | Runs the protected-files-changed guard, and would surface "someone accidentally added a real csproj" |
| `security-scan` | DevSkim scans scripts, workflow YAML, and docs — the template has plenty of all three |

`detect-projects` already sets `has-projects=false` when no projects exist, so the .NET test stages still skip cleanly via their `needs.detect-projects.outputs.has-projects == ''true''` gate.

## Companion change (not in this PR)

The three .NET test-stage required checks (`Stage 1`, `Stage 2`, `Stage 3`) should be **removed from the repo-template branch ruleset** — they fundamentally cannot run on a project-less repo. That is a ruleset edit, not a workflow edit.

## Test plan

- [ ] Verify this PR''s own CI: the three jobs should report ✅ rather than ⏭
- [ ] Three test stages should remain ⏭ (still gated by `has-projects == ''true''`)
- [ ] After this lands + the ruleset trim, PRs #387, #388, #390, #393 should be mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)