### PR TITLE
Address Copilot review comments on #397 (Maintenance section, stderr capture, .NET SDK wording)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ var now = DateTimeOffset.UtcNow;
 ## Build and Test Instructions
 
 ### Prerequisites
-- .NET 10.0 SDK or later (required for the repo's net10.0 target; older SDKs cannot load the csproj)
+- Latest .NET SDK recommended (the CI matrix tests .NET 5.0-10.0 and .NET Framework 4.6.2-4.8.1; the SDK you actually need depends on your project's target frameworks. The template itself contains no csproj.)
 - PowerShell Core (optional, for formatting scripts)
 
 ### Build the Project

--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -86,6 +86,23 @@ The canonical list lives in `scripts/Setup-Labels.ps1`; today it is:
 
 Requires the [GitHub CLI](https://cli.github.com/) to be installed and authenticated (`gh auth login`).
 
+## Set Up the Maintenance Framework
+
+After the labels exist, provision the per-repo parent **Maintenance** issue
+and its standard sub-issues (security, performance, testing, cleanup, docs,
+API, CI/CD). The `Maintenance: <repo>` parent issue is referenced by
+`.github/copilot-instructions.md` and the downstream maintenance workflows;
+if you skip this step those references point at a non-existent issue.
+
+```powershell
+pwsh -File ./scripts/Setup-Maintenance.ps1
+```
+
+This is a one-time step per repo. The script is idempotent - re-running it
+updates the existing parent issue rather than creating duplicates.
+
+Requires `gh auth login` (same prerequisite as the labels script).
+
 
 ## Creating the project
 

--- a/scripts/Setup-BranchRuleset.ps1
+++ b/scripts/Setup-BranchRuleset.ps1
@@ -107,6 +107,7 @@ try {
     # valid JSON and breaks ConvertFrom-Json. Redirect stderr to a temp file
     # so gh's progress/warnings can't poison the JSON stream on stdout.
     $rulesetErr = [System.IO.Path]::GetTempFileName()
+    $rulesetErrText = $null
     try {
         $rulesetOutput = gh api `
             -H "Accept: application/vnd.github+json" `
@@ -115,11 +116,17 @@ try {
             --paginate `
             --jq '[ .[] | select(.name == "Protect main branch") ]' 2> $rulesetErr
     } finally {
-        if (Test-Path -LiteralPath $rulesetErr) { Remove-Item -LiteralPath $rulesetErr -Force }
+        if (Test-Path -LiteralPath $rulesetErr) {
+            # Capture stderr before deletion so the warning below has
+            # diagnostic content. Mirrors Fix-BranchRuleset.ps1 (~line 115).
+            $rulesetErrText = (Get-Content -LiteralPath $rulesetErr -Raw -ErrorAction SilentlyContinue)
+            Remove-Item -LiteralPath $rulesetErr -Force
+        }
     }
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Warning "⚠️  Could not check for existing rulesets (API returned exit code $LASTEXITCODE). Continuing..."
+        $errSuffix = if ([string]::IsNullOrWhiteSpace($rulesetErrText)) { '' } else { " gh stderr: $($rulesetErrText.Trim())" }
+        Write-Warning "⚠️  Could not check for existing rulesets (API returned exit code $LASTEXITCODE).$errSuffix Continuing..."
     } elseif ($rulesetOutput) {
         $matchingRulesets = $rulesetOutput | ConvertFrom-Json
         $existingRuleset = @($matchingRulesets) | Select-Object -First 1


### PR DESCRIPTION
## Summary

Addresses the three unresolved Copilot review comments on #397 (vNext -> main).

| # | File | Concern (Copilot) | Fix |
|---|---|---|---|
| 1 | `REPO-INSTRUCTIONS.md` | The "Set Up the Maintenance Framework" section was removed entirely. `setup.ps1` only prints the `Setup-Maintenance.ps1` command, it does not run it, so users following either Quick Start or the manual fallback never get told to create the parent `Maintenance: <repo>` issue (which `.github/copilot-instructions.md` lines 192-197 still require). | Restored the section between `## Add Custom Labels` and `## Creating the project`. Documents what the parent issue is, why it matters, and how to run `Setup-Maintenance.ps1`. Calls out the idempotent behaviour. |
| 2 | `scripts/Setup-BranchRuleset.ps1` | stderr from `gh api` is captured to `$rulesetErr` but the temp file is deleted in `finally` without ever being read. When `$LASTEXITCODE -ne 0`, the warning only prints the exit code with no diagnostic. The sibling `Fix-BranchRuleset.ps1` (line 115) already shows the right pattern. | Read the temp file's contents into `$rulesetErrText` in `finally` *before* deletion and append it to the warning when present. Mirrors `Fix-BranchRuleset.ps1` exactly. |
| 3 | `CONTRIBUTING.md` | ".NET 10.0 SDK or later (required for the repo''s net10.0 target; older SDKs cannot load the csproj)" overstates the constraint: the template has no csproj files, and the CI matrix tests .NET 5.0-10.0 / Framework 4.6.2-4.8.1. | Reworded to "Latest .NET SDK recommended (the CI matrix tests .NET 5.0-10.0 and .NET Framework 4.6.2-4.8.1; the SDK you actually need depends on your project''s target frameworks. The template itself contains no csproj.)" |

## Why a separate PR

These touch files that are already on `vNext` via #397. Landing them here as their own reviewable change keeps the Copilot-feedback resolution distinct from the much larger #397 diff. After this merges, #397 picks up the fixes via vNext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)