### PR TITLE
Repo-review follow-ups: restore TEMPLATE-PLACEHOLDERS, drop stale LICENSE-SELECTION ref, self-delete one-time scripts, document missing scripts + Stryker

### DIFF
--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -25,16 +25,50 @@ Below is a list of what needs to be done. Once you have completed the checklist 
 
 ## Add Branch Protection Rules
 
-Configure branch protection rules for the `main` branch:
+The fastest path is the bundled script. It provisions the full canonical
+ruleset (required status checks, code-scanning gate, force-push protection,
+conversation-resolution requirement, Copilot code review) in one command:
 
-1. Go to your repository’s Settings → Branches.
-2. Under “Branch protection rules,” click `Add branch ruleset`
-3. `Ruleset Name` enter `main`
-4. `Target branches` click `Add target`
-5. Select `Include by pattern`
-6. `Branch naming pattern` enter `main`
-7. Click `Add Inclusion pattern`
+```powershell
+pwsh -File ./scripts/Setup-BranchRuleset.ps1
+```
 
+The script auto-detects the current repository, prompts you to pick
+**single-developer** (no approvals required - you can merge your own PRs)
+vs. **multi-developer** (one approval + code-owner review), and self-deletes
+when it succeeds. Restore it from the template if the ruleset ever needs to
+be re-created.
+
+If the live ruleset drifts (e.g. a required check name changes upstream and
+PRs get stuck waiting for a check that will never report), run:
+
+```powershell
+pwsh -File ./scripts/Fix-BranchRuleset.ps1
+```
+
+This inspects the live ruleset and prompts to repair any divergence from the
+canonical shape.
+
+### Manual fallback (UI only)
+
+Only use this path if `Setup-BranchRuleset.ps1` does not fit your scenario
+(e.g. you are adopting this layout in a non-template repo that does not have
+the script).
+
+1. Go to your repository''s **Settings > Rules > Rulesets**.
+2. Click **New ruleset > New branch ruleset**.
+3. **Ruleset Name** enter `Protect main branch`.
+4. **Enforcement status** set to **Active**.
+5. **Target branches > Add target > Include by pattern** enter `main`.
+6. Under **Branch rules**, enable:
+   - Restrict creations / deletions / non-fast-forward updates
+   - Require a pull request before merging, with conversation-resolution required
+   - Require status checks to pass - add the contexts listed in
+     [scripts/Setup-BranchRuleset.ps1](scripts/Setup-BranchRuleset.ps1)
+     (Stage 1/2/3 Linux/Windows/macOS, Detect .NET Projects, Secrets Scan
+     (gitleaks), Security Scan (DevSkim), Security Scan (CodeQL) (csharp))
+   - Require code scanning results from CodeQL, errors threshold
+7. Save the ruleset.
 
 ## Security Settings
 
@@ -181,27 +215,43 @@ After creating your repository from the template, update the following files wit
 
 ### Setup GitHub Pages for Documentation (Optional)
 
-If you want to publish your DocFX documentation to GitHub Pages automatically when you publish a GitHub Release:
+The fastest path is the bundled script. It creates the `gh-pages` branch if
+needed, enables Pages on it, substitutes the docfx placeholders for the
+current repo, and self-deletes when it succeeds:
 
-1. Set up GitHub Pages manually:
-   - Go to your repository's **Settings → Pages**
-   - Under "Build and deployment," select **Deploy from a branch**
-   - Select the `gh-pages` branch (create it if it doesn't exist: `git checkout --orphan gh-pages && git push origin gh-pages`)
-   - Save the settings
-   - Update the DocFX configuration files in `docfx_project/` to replace placeholders (e.g., `{{PROJECT_NAME}}`, `{{DOCS_URL}}`) with your project's values
+```powershell
+pwsh -File ./scripts/Setup-GitHubPages.ps1
+```
 
-2. Documentation will be automatically published when you publish a GitHub Release:
-   1. Go to your repository's **Releases** page
-   2. Click **"Draft a new release"**
-   3. Choose or create a version tag (e.g., `v1.0.0`)
-   4. Click **"Publish release"**
+After this runs, publishing a GitHub Release fires `release.yaml`, which
+calls `docfx.yaml` to build the docs and publish them to `gh-pages`. Docs
+are served at `https://[username].github.io/[repo-name]/`.
 
-3. The documentation will be available at: `https://[username].github.io/[repo-name]/`
+After a docs deploy, validate the result with:
 
-**Note:** The DocFX workflow (`.github/workflows/docfx.yaml`) is configured to trigger via:
-- **`workflow_call`**: Called automatically by `release.yaml` after a GitHub Release is published (passes the release tag as the version)
-- **`workflow_dispatch`**: Manual trigger for ad-hoc builds or dry-runs (available from the Actions tab)
+```bash
+bash ./scripts/Validate-DocsDeploy.sh
+```
 
+This inspects the live `gh-pages` content (`index.html`, `versions.json`,
+every version folder, the `latest/` alias) and reports drift from the
+expected layout. Useful for catching botched deploys before readers notice.
+
+**The DocFX workflow trigger**:
+- **`workflow_call`** - invoked by `release.yaml` after a GitHub Release is
+  published (passes the release tag as the version)
+- **`workflow_dispatch`** - manual trigger for ad-hoc builds or dry-runs
+
+#### Manual fallback (UI only)
+
+Only use this path if `Setup-GitHubPages.ps1` does not fit your scenario.
+
+1. **Settings > Pages**: set source to **Deploy from a branch**, branch
+   `gh-pages` (`git checkout --orphan gh-pages && git push origin gh-pages`
+   if it does not exist).
+2. Edit `docfx_project/docfx.json` and surrounding files to replace
+   `{{PROJECT_NAME}}`, `{{DOCS_URL}}`, etc. with your project values.
+3. Publish a GitHub Release to fire the workflow.
 
 ### Update Documentation (Optional)
 
@@ -236,3 +286,30 @@ When you publish a new release (e.g. `v1.0.0`):
 The DocFX modern template is configured to default to dark mode. This is controlled by:
 - `"colorMode": "dark"` in `docfx_project/docfx.json` → `build.globalMetadata`
 - `"_enableDarkMode": true` enables the light/dark toggle so visitors can switch themes
+
+## Maintenance & Repair Scripts
+
+After the one-time setup scripts have self-deleted, these helpers stay around
+because they are useful in steady-state:
+
+| Script | When to use |
+|---|---|
+| `scripts/Fix-BranchRuleset.ps1` | Repair the branch ruleset if a check name changes upstream and the rule gets stuck waiting. Inspects and patches in place; does not recreate from scratch. |
+| `scripts/Setup-Labels.ps1` | Re-run when new canonical labels are added (e.g. a new `maintenance - X` kind). Idempotent. |
+| `scripts/Validate-DocsDeploy.sh` | Post-deploy validation of the `gh-pages` branch. See the **Setup GitHub Pages** section above. |
+| `scripts/build-pr.ps1` | Local dry-run of the full PR CI matrix (Linux Stage 1 + Windows Stage 2 + macOS Stage 3). Useful before pushing a workflow change to confirm it still passes. |
+| `scripts/format.ps1` | One-shot formatter (CSharpier + analyzer auto-fixups). Mirrors what the CI build expects, so running it locally avoids surprise CI failures. |
+
+
+## Mutation Testing (Optional)
+
+`.github/workflows/stryker.yaml` provides a Stryker.NET mutation-testing
+workflow. The workflow runs on demand only (`workflow_dispatch`). To enable
+for your repo, drop a `stryker-config.json` next to your test project; the
+workflow picks it up automatically. Per-repo enablement is a separate
+decision - the canonical workflow lives in the template so every repo can
+opt in without re-deriving the YAML.
+
+Mutation testing is expensive (it re-runs the suite once per mutated source
+line). Run it ad-hoc when you want a sanity check on test-suite quality;
+do not gate every PR on it.

--- a/TEMPLATE-PLACEHOLDERS.md
+++ b/TEMPLATE-PLACEHOLDERS.md
@@ -1,0 +1,421 @@
+# Template Placeholders Documentation
+
+This document provides comprehensive documentation of all placeholders used in this repository template and instructions for replacing them.
+
+## Overview
+
+The automated setup script (`pwsh ./scripts/setup.ps1`) handles all placeholder replacements automatically. This document is for reference or manual setup if needed.
+
+---
+
+## Placeholder Format
+
+All placeholders use the format: `{{PLACEHOLDER_NAME}}`
+
+**Example:** `{{PROJECT_NAME}}` becomes `Wolfgang.Extensions.IAsyncEnumerable`
+
+---
+
+## Core Placeholders
+
+These placeholders are **required** and must be replaced in every project:
+
+| Placeholder | Description | Example Value | Auto-detected? |
+|------------|-------------|---------------|----------------|
+| `{{PROJECT_NAME}}` | Full project/library name | `Wolfgang.Extensions.IAsyncEnumerable` | No |
+| `{{PROJECT_DESCRIPTION}}` | One-line project description | `High-performance extension methods for IAsyncEnumerable<T>` | No |
+| `{{PACKAGE_NAME}}` | NuGet package name | `Wolfgang.Extensions.IAsyncEnumerable` | No (usually same as PROJECT_NAME) |
+| `{{GITHUB_REPO_URL}}` | Full GitHub repository URL | `https://github.com/Chris-Wolfgang/MyProject` | Yes (from `git remote`) |
+| `{{REPO_NAME}}` | Repository name only | `MyProject` | Yes (extracted from URL) |
+| `{{GITHUB_USERNAME}}` | GitHub username with @ | `@Chris-Wolfgang` | Yes (from GitHub repo URL, or prompted if missing) |
+| `{{DOCS_URL}}` | Documentation URL | `https://chris-wolfgang.github.io/MyProject/` | Yes (generated from repo URL) |
+| `{{LICENSE_TYPE}}` | License identifier | `MIT`, `Apache-2.0`, or `MPL-2.0` | No |
+| `{{YEAR}}` | Copyright year | `2024` | Yes (current year) |
+| `{{COPYRIGHT_HOLDER}}` | Copyright owner name | `Chris Wolfgang` | Yes (from `git config`) |
+| `{{NUGET_STATUS}}` | NuGet availability message | `Coming soon to NuGet.org` or `Available on NuGet.org` | No |
+| `{{TEMPLATE_REPO_OWNER}}` | Template repository owner (used in setup docs) | `Chris-Wolfgang` | No (prompted during setup) |
+| `{{TEMPLATE_REPO_NAME}}` | Template repository name (used in setup docs) | `repo-template` | No (prompted during setup) |
+
+---
+
+## Optional Content Placeholders
+
+These placeholders represent sections that users should fill in later. They can remain as placeholders initially:
+
+| Placeholder | Purpose | Location |
+|------------|---------|----------|
+| `{{QUICK_START_EXAMPLE}}` | Code example showing basic usage | README.md |
+| `{{FEATURES_TABLE}}` | Markdown table listing features | README.md |
+| `{{FEATURE_EXAMPLES}}` | Code examples demonstrating features | README.md |
+| `{{TARGET_FRAMEWORKS}}` | List of supported .NET frameworks | README.md |
+| `{{ACKNOWLEDGMENTS}}` | Credits for libraries/tools used | README.md |
+
+**Note:** The automated setup scripts do NOT replace these - users fill them in as they develop their project.
+
+---
+
+## Template Identification Placeholders
+
+### Purpose of TEMPLATE_REPO_OWNER and TEMPLATE_REPO_NAME
+
+The `{{TEMPLATE_REPO_OWNER}}` and `{{TEMPLATE_REPO_NAME}}` placeholders identify the original template repository used to create a new project. These values are primarily used in setup documentation to ensure that instructions accurately reference the actual template source.
+
+### Why This Matters
+
+When users:
+1. Fork the template to customize it
+2. Create their own variant of this template
+3. Use a customized version within an organization
+
+The setup instructions should reference the **actual template they used**, not the original upstream template. This prevents confusion during onboarding and documentation.
+
+### Default Values
+
+- **TEMPLATE_REPO_OWNER**: `Chris-Wolfgang` (the original template owner)
+- **TEMPLATE_REPO_NAME**: `repo-template` (the original template name)
+
+These defaults work for most users creating repositories directly from the original template.
+
+### When to Use Custom Values
+
+Users should provide custom values when:
+- Using a forked version of the template
+- Using an organization-specific template variant
+- The template has been renamed or moved to a different owner
+- Creating documentation for a derivative template
+
+### How These Values Are Collected
+
+The setup script (`pwsh ./scripts/setup.ps1`) prompts users for this information:
+
+**PowerShell (setup.ps1):**
+```powershell
+$templateRepoOwner = Read-Input `
+    -Prompt "Template Repository Owner" `
+    -Default "Chris-Wolfgang" `
+    -Example "YourUsername"
+
+$templateRepoName = Read-Input `
+    -Prompt "Template Repository Name" `
+    -Default "repo-template" `
+    -Example "my-template"
+```
+
+These values are collected during the interactive setup process (lines 341-349 in setup.ps1) and added to the replacements hashtable (lines 390-391).
+
+### Where These Are Used
+
+The primary usage is in `REPO-INSTRUCTIONS.md` where the setup instructions reference the template:
+
+**Before replacement (line 46):**
+```markdown
+1. `Start with a template` select `{{TEMPLATE_REPO_OWNER}}/{{TEMPLATE_REPO_NAME}}`
+```
+
+**After replacement (using default values):**
+```markdown
+1. `Start with a template` select `Chris-Wolfgang/repo-template`
+```
+
+**After replacement (using custom values):**
+```markdown
+1. `Start with a template` select `YourUsername/my-template`
+```
+
+### Validation
+
+The setup script validates that these placeholders are properly replaced (along with other core placeholders) before completing:
+
+**PowerShell (setup.ps1, lines 475-479):**
+```powershell
+$corePlaceholders = @(
+    'PROJECT_NAME', 'PROJECT_DESCRIPTION', 'PACKAGE_NAME',
+    'GITHUB_REPO_URL', 'REPO_NAME', 'GITHUB_USERNAME',
+    'DOCS_URL', 'LICENSE_TYPE',
+    'NUGET_STATUS', 'TEMPLATE_REPO_OWNER', 'TEMPLATE_REPO_NAME'
+)
+```
+
+**Files That Process These Placeholders:**
+1. **scripts/setup.ps1** - PowerShell setup script (prompts: lines 341-349; replacements hashtable: lines 390-391)
+2. **REPO-INSTRUCTIONS.md** - Target file where replacement occurs (line 46)
+
+---
+
+## Files Containing Placeholders
+
+### 1. README.md (After Rename)
+
+**Important:** `README-TEMPLATE.md` becomes `README.md` during setup.
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 1 | `{{PROJECT_NAME}}` | Main heading |
+| 3 | `{{PROJECT_DESCRIPTION}}` | Project description |
+| 5 | `{{LICENSE_TYPE}}` | License badge |
+| 7 | `{{GITHUB_REPO_URL}}` | GitHub badge link |
+| 13 | `{{PACKAGE_NAME}}` | Installation command |
+| 16 | `{{NUGET_STATUS}}` | NuGet availability |
+| 21 | `{{LICENSE_TYPE}}` | License section |
+| 27 | `{{GITHUB_REPO_URL}}` | Documentation link (2 occurrences) |
+| 28 | `{{DOCS_URL}}` | API documentation URL |
+| 35 | `{{QUICK_START_EXAMPLE}}` | Quick start code |
+| 41 | `{{FEATURES_TABLE}}` | Features table |
+| 44 | `{{FEATURE_EXAMPLES}}` | Feature examples |
+| 50 | `{{TARGET_FRAMEWORKS}}` | Framework list |
+| 119 | `{{GITHUB_REPO_URL}}` | Clone command |
+| 120 | `{{REPO_NAME}}` | Directory name |
+| 197 | `{{ACKNOWLEDGMENTS}}` | Acknowledgments section |
+
+### 2. CONTRIBUTING.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 1 | `{{PROJECT_NAME}}` | Main heading |
+| 3 | `{{PROJECT_NAME}}` | Introduction paragraph |
+
+### 3. .github/CODEOWNERS
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 5 | `{{GITHUB_USERNAME}}` | Default owner |
+| 8 | `{{GITHUB_USERNAME}}` | src/ directory (commented) |
+| 11 | `{{GITHUB_USERNAME}}` | docs/ directory (commented) |
+| 14 | `{{GITHUB_USERNAME}}` | workflows/ directory (commented) |
+| 17 | `{{GITHUB_USERNAME}}` | .github/ directory |
+
+### 4. REPO-INSTRUCTIONS.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 46 | `{{TEMPLATE_REPO_OWNER}}/{{TEMPLATE_REPO_NAME}}` | Template selection instruction |
+| ~135 | `{{GITHUB_USERNAME}}` | CODEOWNERS update instruction |
+
+### 5. scripts/Setup-BranchRuleset.ps1
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 37 | `{{GITHUB_USERNAME}}/{{REPO_NAME}}` | Default repository parameter |
+
+**Note:** This file is automatically updated during setup to contain your repository information. After setup, the script will automatically use the correct repository without needing to auto-detect or pass parameters.
+
+### 6. License Files (Selected During Setup)
+
+**LICENSE-MIT.txt:**
+- Line 3: `{{YEAR}}` and `{{COPYRIGHT_HOLDER}}`
+
+**LICENSE-APACHE-2.0.txt:**
+- Line 189: `{{YEAR}}` and `{{COPYRIGHT_HOLDER}}`
+
+**LICENSE-MPL-2.0.txt:**
+- No placeholders (license text is complete)
+- Copyright notice added separately if needed
+
+### 6. docfx_project/docfx.json
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 46 | `{{PROJECT_NAME}}` | Application name |
+| 47 | `{{PROJECT_NAME}}` | Application title |
+| 53 | `{{DOCS_URL}}` | Base URL for documentation |
+
+### 7. docfx_project/index.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 5 | `{{PROJECT_NAME}}` | Main heading |
+| 7 | `{{PROJECT_NAME}}` | Welcome message |
+| 13 | `{{GITHUB_REPO_URL}}` | GitHub repository link |
+| 15 | `{{PROJECT_NAME}}` | About section |
+| 17 | `{{PROJECT_DESCRIPTION}}` | About section |
+| 22 | `{{PACKAGE_NAME}}` | Installation command |
+| 35-37 | `{{GITHUB_REPO_URL}}` | Additional resources links (3 occurrences) |
+
+### 8. docfx_project/api/index.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 3 | `{{PROJECT_NAME}}` | Welcome message |
+
+### 9. docfx_project/docs/toc.yml
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| Various | `{{GITHUB_REPO_URL}}` | Project website link |
+
+### 10. docfx_project/docs/introduction.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| Various | `{{PROJECT_NAME}}`, `{{PROJECT_DESCRIPTION}}` | Introduction headings and descriptive text |
+| Various | `{{GITHUB_REPO_URL}}` | Links back to the GitHub repository from the introduction |
+
+### 11. docfx_project/docs/getting-started.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| Various | `{{PROJECT_NAME}}` | Getting started headings and examples |
+| Various | `{{PACKAGE_NAME}}` | NuGet installation and package reference snippets |
+| Various | `{{GITHUB_REPO_URL}}` | Links to source code, issues, and documentation on GitHub |
+
+### 9. docfx_project/docs/toc.yml
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 8 | `{{GITHUB_REPO_URL}}` | Project website link |
+
+### 10. docfx_project/docs/introduction.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 3 | `{{PROJECT_NAME}}` | Welcome message |
+| 7 | `{{PROJECT_DESCRIPTION}}` | Overview section |
+| 21 | `{{PROJECT_NAME}}` | Getting help section |
+| 25 | `{{GITHUB_REPO_URL}}` | GitHub repository link |
+| 26 | `{{GITHUB_REPO_URL}}` | GitHub issues link |
+
+### 11. docfx_project/docs/getting-started.md
+
+| Line(s) | Placeholder | Context |
+|---------|-------------|---------|
+| 3 | `{{PROJECT_NAME}}` | Guide title |
+| 17 | `{{PACKAGE_NAME}}` | NuGet installation command |
+| 23 | `{{PACKAGE_NAME}}` | Package Manager Console command |
+| 34 | `{{PROJECT_NAME}}` | Using statement in code example |
+| 42 | `{{PROJECT_NAME}}` | Next steps section |
+| 43 | `{{GITHUB_REPO_URL}}` | GitHub repository link |
+| 51 | `{{GITHUB_REPO_URL}}` | Additional resources |
+| 52 | `{{GITHUB_REPO_URL}}` | Contributing guidelines link |
+| 53 | `{{GITHUB_REPO_URL}}` | Issue reporting link |
+
+---
+
+## Replacement Process
+
+### Automated (Recommended)
+
+The setup scripts handle all replacements automatically:
+
+```powershell
+pwsh ./scripts/setup.ps1
+```
+
+### Manual Replacement
+
+If you must replace manually:
+
+1. **README File Swap:**
+   ```bash
+   rm README.md
+   mv README-TEMPLATE.md README.md
+   ```
+
+2. **License Setup:**
+   - Choose a license template (e.g., `LICENSE-MIT.txt`)
+   - Replace `{{YEAR}}` and `{{COPYRIGHT_HOLDER}}`
+   - Save as `LICENSE` (no extension)
+   - Delete all `LICENSE-*.txt` files
+
+3. **Global Find and Replace** in your editor:
+   - Search for: `{{PLACEHOLDER_NAME}}`
+   - Replace with: `Your Value`
+   - Files to search:
+     - `README.md` (now the renamed template)
+     - `CONTRIBUTING.md`
+     - `.github/CODEOWNERS`
+     - `REPO-INSTRUCTIONS.md`
+     - `LICENSE-SELECTION.md`
+     - `docfx_project/docfx.json`
+     - `docfx_project/index.md`
+     - `docfx_project/api/index.md`
+     - `docfx_project/api/README.md`
+     - `docfx_project/docs/toc.yml`
+     - `docfx_project/docs/introduction.md`
+     - `docfx_project/docs/getting-started.md`
+
+4. **Validation:**
+   ```bash
+   # Check for remaining required placeholders
+   # Note: README.md will still contain optional placeholders like {{QUICK_START_EXAMPLE}},
+   # {{FEATURES_TABLE}}, {{FEATURE_EXAMPLES}}, {{TARGET_FRAMEWORKS}}, {{ACKNOWLEDGMENTS}}
+   # which you fill in as you develop your project
+   grep -r "{{.*}}" CONTRIBUTING.md .github/CODEOWNERS REPO-INSTRUCTIONS.md LICENSE-SELECTION.md docfx_project/ || echo "No required placeholders found in core files"
+   
+   # Check README.md separately for required placeholders only
+   grep -E "{{(PROJECT_NAME|PROJECT_DESCRIPTION|PACKAGE_NAME|GITHUB_REPO_URL|REPO_NAME|DOCS_URL|LICENSE_TYPE|NUGET_STATUS)}}" README.md && echo "⚠️  Found required placeholders in README.md - please replace them" || echo "✓ All required placeholders replaced in README.md"
+   ```
+
+---
+
+## Example Replacement Values
+
+Here's a complete example for a hypothetical project:
+
+```
+{{PROJECT_NAME}}              → Wolfgang.Net.HttpClient.Extensions
+{{PROJECT_DESCRIPTION}}       → Extension methods for HttpClient with retry policies and resilience
+{{PACKAGE_NAME}}              → Wolfgang.Net.HttpClient.Extensions
+{{GITHUB_REPO_URL}}           → https://github.com/Chris-Wolfgang/HttpClient-Extensions
+{{REPO_NAME}}                 → HttpClient-Extensions
+{{GITHUB_USERNAME}}           → @Chris-Wolfgang
+{{DOCS_URL}}                  → https://chris-wolfgang.github.io/HttpClient-Extensions/
+{{LICENSE_TYPE}}              → MIT
+{{YEAR}}                      → 2024
+{{COPYRIGHT_HOLDER}}          → Chris Wolfgang
+{{NUGET_STATUS}}              → Coming soon to NuGet.org
+{{TEMPLATE_REPO_OWNER}}       → Chris-Wolfgang
+{{TEMPLATE_REPO_NAME}}        → repo-template
+```
+
+---
+
+## Validation Checklist
+
+After replacement, verify:
+
+- [ ] All required placeholders are replaced
+- [ ] No `{{...}}` patterns remain in core files
+- [ ] README.md exists (from README-TEMPLATE.md)
+- [ ] LICENSE file exists (no .txt extension)
+- [ ] CODEOWNERS has your GitHub username
+- [ ] CONTRIBUTING.md has your project name
+- [ ] All URLs are correct and accessible
+- [ ] License type matches your LICENSE file
+
+---
+
+## Troubleshooting
+
+### Issue: Placeholder not found in file
+
+**Cause:** The file may have been manually edited before running setup.
+
+**Solution:** Check the file manually or re-clone from template.
+
+### Issue: Wrong value auto-detected
+
+**Cause:** Git configuration or remote URL is incorrect.
+
+**Solution:** The setup script allows manual override of all values.
+
+### Issue: Remaining placeholders after setup
+
+**Cause:** Some placeholders are intentionally left for users to fill (e.g., `{{QUICK_START_EXAMPLE}}`).
+
+**Solution:** Fill these in as you develop your project.
+
+---
+
+## Additional Resources
+
+- **Setup Script:** `pwsh ./scripts/setup.ps1`
+- **License Selection Guide:** [LICENSE-SELECTION.md](LICENSE-SELECTION.md)
+- **Repository Instructions:** [REPO-INSTRUCTIONS.md](REPO-INSTRUCTIONS.md)
+- **Template README:** [README.md](README.md) (describes template)
+- **Project README Template:** [README-TEMPLATE.md](README-TEMPLATE.md)
+
+---
+
+## Contributing
+
+Found an issue with placeholder documentation? Please open an issue or submit a pull request!

--- a/TEMPLATE-PLACEHOLDERS.md
+++ b/TEMPLATE-PLACEHOLDERS.md
@@ -211,7 +211,7 @@ $corePlaceholders = @(
 - No placeholders (license text is complete)
 - Copyright notice added separately if needed
 
-### 6. docfx_project/docfx.json
+### 7. docfx_project/docfx.json
 
 | Line(s) | Placeholder | Context |
 |---------|-------------|---------|
@@ -219,7 +219,7 @@ $corePlaceholders = @(
 | 47 | `{{PROJECT_NAME}}` | Application title |
 | 53 | `{{DOCS_URL}}` | Base URL for documentation |
 
-### 7. docfx_project/index.md
+### 8. docfx_project/index.md
 
 | Line(s) | Placeholder | Context |
 |---------|-------------|---------|
@@ -231,40 +231,19 @@ $corePlaceholders = @(
 | 22 | `{{PACKAGE_NAME}}` | Installation command |
 | 35-37 | `{{GITHUB_REPO_URL}}` | Additional resources links (3 occurrences) |
 
-### 8. docfx_project/api/index.md
+### 9. docfx_project/api/index.md
 
 | Line(s) | Placeholder | Context |
 |---------|-------------|---------|
 | 3 | `{{PROJECT_NAME}}` | Welcome message |
 
-### 9. docfx_project/docs/toc.yml
-
-| Line(s) | Placeholder | Context |
-|---------|-------------|---------|
-| Various | `{{GITHUB_REPO_URL}}` | Project website link |
-
-### 10. docfx_project/docs/introduction.md
-
-| Line(s) | Placeholder | Context |
-|---------|-------------|---------|
-| Various | `{{PROJECT_NAME}}`, `{{PROJECT_DESCRIPTION}}` | Introduction headings and descriptive text |
-| Various | `{{GITHUB_REPO_URL}}` | Links back to the GitHub repository from the introduction |
-
-### 11. docfx_project/docs/getting-started.md
-
-| Line(s) | Placeholder | Context |
-|---------|-------------|---------|
-| Various | `{{PROJECT_NAME}}` | Getting started headings and examples |
-| Various | `{{PACKAGE_NAME}}` | NuGet installation and package reference snippets |
-| Various | `{{GITHUB_REPO_URL}}` | Links to source code, issues, and documentation on GitHub |
-
-### 9. docfx_project/docs/toc.yml
+### 10. docfx_project/docs/toc.yml
 
 | Line(s) | Placeholder | Context |
 |---------|-------------|---------|
 | 8 | `{{GITHUB_REPO_URL}}` | Project website link |
 
-### 10. docfx_project/docs/introduction.md
+### 11. docfx_project/docs/introduction.md
 
 | Line(s) | Placeholder | Context |
 |---------|-------------|---------|
@@ -274,7 +253,7 @@ $corePlaceholders = @(
 | 25 | `{{GITHUB_REPO_URL}}` | GitHub repository link |
 | 26 | `{{GITHUB_REPO_URL}}` | GitHub issues link |
 
-### 11. docfx_project/docs/getting-started.md
+### 12. docfx_project/docs/getting-started.md
 
 | Line(s) | Placeholder | Context |
 |---------|-------------|---------|
@@ -324,7 +303,6 @@ If you must replace manually:
      - `CONTRIBUTING.md`
      - `.github/CODEOWNERS`
      - `REPO-INSTRUCTIONS.md`
-     - `LICENSE-SELECTION.md`
      - `docfx_project/docfx.json`
      - `docfx_project/index.md`
      - `docfx_project/api/index.md`
@@ -339,7 +317,7 @@ If you must replace manually:
    # Note: README.md will still contain optional placeholders like {{QUICK_START_EXAMPLE}},
    # {{FEATURES_TABLE}}, {{FEATURE_EXAMPLES}}, {{TARGET_FRAMEWORKS}}, {{ACKNOWLEDGMENTS}}
    # which you fill in as you develop your project
-   grep -r "{{.*}}" CONTRIBUTING.md .github/CODEOWNERS REPO-INSTRUCTIONS.md LICENSE-SELECTION.md docfx_project/ || echo "No required placeholders found in core files"
+   grep -r "{{.*}}" CONTRIBUTING.md .github/CODEOWNERS REPO-INSTRUCTIONS.md docfx_project/ || echo "No required placeholders found in core files"
    
    # Check README.md separately for required placeholders only
    grep -E "{{(PROJECT_NAME|PROJECT_DESCRIPTION|PACKAGE_NAME|GITHUB_REPO_URL|REPO_NAME|DOCS_URL|LICENSE_TYPE|NUGET_STATUS)}}" README.md && echo "⚠️  Found required placeholders in README.md - please replace them" || echo "✓ All required placeholders replaced in README.md"
@@ -360,7 +338,7 @@ Here's a complete example for a hypothetical project:
 {{GITHUB_USERNAME}}           → @Chris-Wolfgang
 {{DOCS_URL}}                  → https://chris-wolfgang.github.io/HttpClient-Extensions/
 {{LICENSE_TYPE}}              → MIT
-{{YEAR}}                      → 2024
+{{YEAR}}                      → 2026
 {{COPYRIGHT_HOLDER}}          → Chris Wolfgang
 {{NUGET_STATUS}}              → Coming soon to NuGet.org
 {{TEMPLATE_REPO_OWNER}}       → Chris-Wolfgang
@@ -409,7 +387,6 @@ After replacement, verify:
 ## Additional Resources
 
 - **Setup Script:** `pwsh ./scripts/setup.ps1`
-- **License Selection Guide:** [LICENSE-SELECTION.md](LICENSE-SELECTION.md)
 - **Repository Instructions:** [REPO-INSTRUCTIONS.md](REPO-INSTRUCTIONS.md)
 - **Template README:** [README.md](README.md) (describes template)
 - **Project README Template:** [README-TEMPLATE.md](README-TEMPLATE.md)

--- a/scripts/Setup-BranchRuleset.ps1
+++ b/scripts/Setup-BranchRuleset.ps1
@@ -307,6 +307,20 @@ try {
         
         Write-Host "`n🔗 View ruleset at:" -ForegroundColor Cyan
         Write-Host "   https://github.com/$Repository/settings/rules" -ForegroundColor Blue
+        # Self-delete: this is a one-time bootstrap script. After a successful
+        # ruleset creation, remove the script. Re-run by restoring it from the
+        # template if you need to re-create the ruleset later.
+        $selfPath = $PSCommandPath
+        if ($selfPath -and (Test-Path -LiteralPath $selfPath)) {
+            try {
+                Remove-Item -LiteralPath $selfPath -Force
+                Write-Host ""
+                Write-Host "Self-deleted: $selfPath (one-time bootstrap script)" -ForegroundColor DarkGray
+                Write-Host "   Restore from the template to re-run." -ForegroundColor DarkGray
+            } catch {
+                Write-Warning "Could not self-delete $selfPath - remove manually."
+            }
+        }
     } else {
         Write-Error "❌ Failed to create ruleset"
         Write-Host $response -ForegroundColor Red

--- a/scripts/Setup-GitHubPages.ps1
+++ b/scripts/Setup-GitHubPages.ps1
@@ -717,3 +717,16 @@ try {
 
 Write-Host "`n🎉 GitHub Pages setup complete!" -ForegroundColor Green
 Write-Host ""
+# Self-delete: this is a one-time bootstrap script. After successful Pages
+# configuration, remove the script. Re-run by restoring it from the template
+# if Pages ever needs to be re-bootstrapped.
+$selfPath = $PSCommandPath
+if ($selfPath -and (Test-Path -LiteralPath $selfPath)) {
+    try {
+        Remove-Item -LiteralPath $selfPath -Force
+        Write-Host "Self-deleted: $selfPath (one-time bootstrap script)" -ForegroundColor DarkGray
+        Write-Host "   Restore from the template to re-run." -ForegroundColor DarkGray
+    } catch {
+        Write-Warning "Could not self-delete $selfPath - remove manually."
+    }
+}

--- a/scripts/Setup-Maintenance.ps1
+++ b/scripts/Setup-Maintenance.ps1
@@ -157,3 +157,29 @@ try {
 } finally {
     Remove-Item -Path $bodyFile -ErrorAction SilentlyContinue
 }
+
+# Self-delete: this is a one-time bootstrap script. Also remove the body
+# template (scripts/templates/maintenance-parent-body.md), which is only
+# used by this script. Re-run by restoring both files from the template if
+# the parent Maintenance issue ever needs to be re-created.
+$bodyTemplatePath = Join-Path $scriptDir 'templates/maintenance-parent-body.md'
+if (Test-Path -LiteralPath $bodyTemplatePath) {
+    try {
+        Remove-Item -LiteralPath $bodyTemplatePath -Force
+        Write-Host ""
+        Write-Host "Removed: $bodyTemplatePath" -ForegroundColor DarkGray
+    } catch {
+        Write-Warning "Could not remove $bodyTemplatePath - delete manually."
+    }
+}
+
+$selfPath = $PSCommandPath
+if ($selfPath -and (Test-Path -LiteralPath $selfPath)) {
+    try {
+        Remove-Item -LiteralPath $selfPath -Force
+        Write-Host "Self-deleted: $selfPath (one-time bootstrap script)" -ForegroundColor DarkGray
+        Write-Host "   Restore from the template to re-run." -ForegroundColor DarkGray
+    } catch {
+        Write-Warning "Could not self-delete $selfPath - remove manually."
+    }
+}

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -850,21 +850,23 @@ function Start-Setup {
     # Optional cleanup
     Write-Step "Cleanup"
     Write-Host ""
-    Write-Host "Remove template-specific files? (y/N)" -ForegroundColor Yellow
+    Write-Host "Remove template-only files? (y/N)" -ForegroundColor Yellow
     Write-Host "  Files to remove:" -ForegroundColor Gray
     Write-Host "    - scripts/setup.ps1 (this script)" -ForegroundColor Gray
-    Write-Host "    - LICENSE-SELECTION.md" -ForegroundColor Gray
     Write-Host ""
     Write-Host "  Note: TEMPLATE-PLACEHOLDERS.md will remain for your reference." -ForegroundColor Cyan
-    Write-Host "        Delete it manually when you've reviewed it and no longer need it." -ForegroundColor Cyan
+    Write-Host "        Delete it manually when you have reviewed it and no longer need it." -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  Note: Setup-BranchRuleset.ps1, Setup-GitHubPages.ps1, and Setup-Maintenance.ps1" -ForegroundColor Cyan
+    Write-Host "        each self-delete when you run them successfully - this script only needs" -ForegroundColor Cyan
+    Write-Host "        to remove itself here." -ForegroundColor Cyan
     Write-Host ""
     Write-Host "Remove template files? (y/N): " -NoNewline -ForegroundColor Yellow
     $cleanup = Read-Host
     
     if ($cleanup -eq 'y' -or $cleanup -eq 'Y') {
         $filesToRemove = @(
-            'scripts/setup.ps1',
-            'LICENSE-SELECTION.md'
+            'scripts/setup.ps1'
         )
         
         foreach ($file in $filesToRemove) {
@@ -1018,16 +1020,24 @@ function Start-Setup {
     # Next steps
     Write-Host "✅ Next Steps:" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "1. Configure branch protection (see REPO-INSTRUCTIONS.md if kept)" -ForegroundColor Yellow
+    Write-Host "1. Configure branch protection rules (creates the canonical ruleset)" -ForegroundColor Yellow
+    Write-Host "   pwsh ./scripts/Setup-BranchRuleset.ps1" -ForegroundColor Gray
+    Write-Host "   # Self-deletes on success. Restore from the template to re-run." -ForegroundColor DarkGray
     Write-Host ""
     Write-Host "2. Provision custom labels (includes the Maintenance framework labels)" -ForegroundColor Yellow
     Write-Host "   pwsh ./scripts/Setup-Labels.ps1" -ForegroundColor Gray
+    Write-Host "   # Idempotent - re-run when the canonical label list changes." -ForegroundColor DarkGray
     Write-Host ""
     Write-Host "3. Create the parent Maintenance issue for this repo" -ForegroundColor Yellow
     Write-Host "   pwsh ./scripts/Setup-Maintenance.ps1 -MaintenanceProjectUrl '<url>'" -ForegroundColor Gray
     Write-Host "   # The cross-repo Maintenance project URL — ask the repo owner if you don't have it" -ForegroundColor DarkGray
+    Write-Host "   # Self-deletes on success along with scripts/templates/maintenance-parent-body.md." -ForegroundColor DarkGray
     Write-Host ""
-    Write-Host "4. Start developing!" -ForegroundColor Yellow
+    Write-Host "4. (Optional) Set up GitHub Pages for documentation" -ForegroundColor Yellow
+    Write-Host "   pwsh ./scripts/Setup-GitHubPages.ps1" -ForegroundColor Gray
+    Write-Host "   # Self-deletes on success. Restore from the template to re-run." -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "5. Start developing!" -ForegroundColor Yellow
     if ($solutionName) {
         Write-Host "   # Solution file created: $solutionName.slnx" -ForegroundColor Gray
         Write-Host "   # Add your projects to src/ and tests/" -ForegroundColor Gray


### PR DESCRIPTION
## Summary

Follow-up work from the pre-create-new-repo review of `repo-template`. Addresses items 1, 4, 5, 6, 7 from that review plus restoring one file that was deleted in early February and dropping the dead reference to a second.

## What''s in each commit

| Commit | File(s) | Why |
|---|---|---|
| Restore TEMPLATE-PLACEHOLDERS.md | `TEMPLATE-PLACEHOLDERS.md` (new) | Real reference doc that explains all placeholders (including the 5 manual-only ones - `ACKNOWLEDGMENTS`, `FEATURE_EXAMPLES`, `FEATURES_TABLE`, `QUICK_START_EXAMPLE`, `TARGET_FRAMEWORKS`). Was deleted 2026-02-22 in commit `0b9759ad` ("Removed duplicate files in root"); the content was not actually merged anywhere else. `setup.ps1` line 858 still references this file as "remains for your reference" - now true again. |
| Setup-BranchRuleset.ps1 self-delete | `scripts/Setup-BranchRuleset.ps1` | Self-deletes on success. Matches the expectation already encoded in the `template-drift-scan` skill''s `EXCLUDE_RE` (which treats this file as bootstrap-only). |
| Setup-GitHubPages.ps1 self-delete | `scripts/Setup-GitHubPages.ps1` | Same. |
| Setup-Maintenance.ps1 self-delete | `scripts/Setup-Maintenance.ps1` | Self-deletes on success and also removes `scripts/templates/maintenance-parent-body.md` (only used by this script). |
| setup.ps1 cleanup + Next Steps | `scripts/setup.ps1` | (a) Drops the `LICENSE-SELECTION.md` cleanup reference - that file was deleted 2026-02-21 and `setup.ps1` has been trying to delete a nonexistent file ever since. (b) Rewrites Next Steps to explicitly mention `Setup-BranchRuleset.ps1` (replaces the stale "see REPO-INSTRUCTIONS.md if kept" wording, where `REPO-INSTRUCTIONS` is always kept anyway) and adds `Setup-GitHubPages.ps1`. |
| REPO-INSTRUCTIONS.md | `REPO-INSTRUCTIONS.md` | (a) Rewrites the broken "Add Branch Protection Rules" section (which currently ended mid-thought at step 7 with no actual rules configured) to feature `Setup-BranchRuleset.ps1` as the primary path with a real manual fallback. (b) Rewrites the GH-Pages section to feature `Setup-GitHubPages.ps1` + add `Validate-DocsDeploy.sh`. (c) Adds a new **Maintenance & Repair Scripts** section covering the five remaining scripts that had zero mentions (`Fix-BranchRuleset.ps1`, `Setup-Labels.ps1` reuse, `Validate-DocsDeploy.sh`, `build-pr.ps1`, `format.ps1`). (d) Adds a new **Mutation Testing (Optional)** section for `stryker.yaml`, which was orphaned (0 references anywhere). |

## What was already correct (verified during review)

- Workflow check names in `pr.yaml` match the required-checks list in `Setup-BranchRuleset.ps1`
- `CHANGELOG.md` has the canonical Keep-a-Changelog skeleton with `[Unreleased]`
- `Directory.Build.props` has the canonical analyzer set, the tightened SDK-only Nullable condition, and PublicApiAnalyzers
- `tests/.editorconfig` is reasonable (15 test-specific analyzer relaxations)
- Placeholders that should be substituted by `setup.ps1` (`{{PROJECT_NAME}}`, `{{REPO_NAME}}`, etc.) are all in the hashtable at line 456-470

## Items NOT addressed in this PR

- The 5 manual-fill placeholders (`{{ACKNOWLEDGMENTS}}`, etc.) remain unsubstituted on purpose; the restored `TEMPLATE-PLACEHOLDERS.md` documents them so users have a guide.
- `LICENSE-SELECTION.md` is not restored; `setup.ps1` prompts for the license type and handles selection. The 10K guide it used to provide is genuinely redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)