### PR TITLE
stryker.yaml: switch to Windows runner, drop config-file opt-in gate

### DIFF
--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -1,12 +1,19 @@
 # Stryker mutation testing
 #
-# Runs the Stryker.NET mutation tester against the repo's test projects to
-# measure mutation score. Mutation runs are slow — triggered manually
-# (workflow_dispatch) and on a weekly schedule, not on every PR.
+# Mutation testing is canonical for every repo created from this template.
+# The workflow runs Stryker.NET against every test project under tests/ on
+# a Windows runner so it can compile every TFM the repo targets - including
+# .NET Framework 4.6.2-4.8.1, which a Linux runner cannot build.
 #
-# The workflow looks for a stryker-config.json at the repo root or under
-# tests/**/. If none is present the run is a no-op (Stryker setup is a
-# per-repo follow-up; this file is the canonical infrastructure).
+# Triggers:
+# - workflow_dispatch: manual ad-hoc runs (e.g. while iterating on tests)
+# - schedule (weekly Sunday 06:00 UTC): catch quality regressions between
+#   releases without burning CI time on every PR (mutation testing is slow)
+#
+# Stryker discovers each test project's mutation targets via the standard
+# project-reference graph. If a repo wants to tune the run (excluded files,
+# specific mutators, etc.) drop a stryker-config.json next to the test
+# project - dotnet stryker picks it up automatically.
 name: Stryker (mutation testing)
 
 on:
@@ -20,43 +27,19 @@ permissions:
 jobs:
   stryker:
     name: Run Stryker
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Windows runner so Stryker can compile every TFM the repo targets,
+    # including .NET Framework 4.6.2-4.8.1. Linux runners cannot build
+    # net4x, so they would silently mutate only the non-Framework TFMs
+    # and miss bugs that only reproduce on Framework.
+    runs-on: windows-latest
+    timeout-minutes: 120
     steps:
       - name: Check out repo
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - name: Detect stryker-config.json
-        id: check
-        shell: bash
-        run: |
-          # Explicit existence checks rather than globbing — `nullglob` only
-          # drops words that look like patterns (contain *, ?, [). The bare
-          # literal `stryker-config.json` has no glob characters, so it would
-          # be preserved as a literal even when the file doesn't exist, and
-          # the workflow would mistakenly think a config was present.
-          shopt -s globstar nullglob
-          configs=()
-          [ -f stryker-config.json ] && configs+=(stryker-config.json)
-          for cfg in tests/**/stryker-config.json; do
-            [ -f "$cfg" ] && configs+=("$cfg")
-          done
-          if (( ${#configs[@]} )); then
-            printf 'found=true\n' >> "$GITHUB_OUTPUT"
-            # NOTE: previously also wrote a configs<<EOF multi-line output here,
-            # but (a) the downstream Run Stryker step re-globs from scratch and
-            # didn't consume it, and (b) ${configs[*]} joins with spaces so the
-            # value was effectively a single space-separated line — not actually
-            # multi-line. Dropped the dead/broken output.
-          else
-            echo "::notice::No stryker-config.json found — skipping Stryker run. Add one at repo root or under tests/<project>/ to enable mutation testing."
-            printf 'found=false\n' >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup .NET
-        if: steps.check.outputs.found == 'true'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
@@ -64,40 +47,60 @@ jobs:
             10.0.x
 
       - name: Install dotnet-stryker
-        if: steps.check.outputs.found == 'true'
-        run: dotnet tool update -g dotnet-stryker || dotnet tool install -g dotnet-stryker
-
-      - name: Run Stryker
-        if: steps.check.outputs.found == 'true'
-        shell: bash
+        shell: pwsh
         run: |
-          set -e
-          shopt -s globstar nullglob
-          # Run BOTH a root stryker-config.json (if present) AND any
-          # tests/**/stryker-config.json suites. The Detect step collects
-          # both shapes; running only one leaves per-test suites unscanned
-          # in repos that have both an umbrella and per-suite configs.
-          ran=0
-          if [ -f stryker-config.json ]; then
-            echo "::group::Stryker with root stryker-config.json"
+          dotnet tool update -g dotnet-stryker
+          if ($LASTEXITCODE -ne 0) {
+            dotnet tool install -g dotnet-stryker
+          }
+
+      - name: Run Stryker against every test project
+        shell: pwsh
+        run: |
+          # Canonical behavior: no stryker-config.json gate. Stryker runs
+          # against every test project under tests/ using dotnet stryker
+          # defaults; a per-project stryker-config.json overrides those
+          # defaults if present.
+          $tests = @(Get-ChildItem -Path tests -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
+
+          if ($tests.Count -eq 0) {
+            Write-Host "::notice::No test projects found under tests/ - skipping Stryker run."
+            exit 0
+          }
+
+          Write-Host "Found $($tests.Count) test project(s):"
+          $tests | ForEach-Object { Write-Host "  $($_.FullName)" }
+          Write-Host ""
+
+          $failed = 0
+          foreach ($proj in $tests) {
+            $dir = $proj.DirectoryName
+            Write-Host "::group::Stryker in $dir"
+            Push-Location $dir
+            try {
+              dotnet stryker
+              if ($LASTEXITCODE -ne 0) { $failed++ }
+            } finally {
+              Pop-Location
+            }
+            Write-Host "::endgroup::"
+          }
+
+          # Also honor a root-level umbrella config if the repo provides one
+          if (Test-Path 'stryker-config.json') {
+            Write-Host "::group::Stryker with root stryker-config.json"
             dotnet stryker --config-file stryker-config.json
-            echo "::endgroup::"
-            ran=1
-          fi
-          for cfg in tests/**/stryker-config.json; do
-            dir=$(dirname "$cfg")
-            echo "::group::Stryker in $dir"
-            (cd "$dir" && dotnet stryker)
-            echo "::endgroup::"
-            ran=1
-          done
-          if [ "$ran" -eq 0 ]; then
-            echo "::error::Detect step said stryker-config.json was present, but Run found neither root nor tests/**/stryker-config.json. Bailing."
+            if ($LASTEXITCODE -ne 0) { $failed++ }
+            Write-Host "::endgroup::"
+          }
+
+          if ($failed -gt 0) {
+            Write-Host "::error::$failed Stryker run(s) failed"
             exit 1
-          fi
+          }
 
       - name: Upload Stryker report
-        if: always() && steps.check.outputs.found == 'true'
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: stryker-report-${{ github.run_id }}

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -91,7 +91,7 @@ jobs:
             Write-Host "::endgroup::"
           }
           else {
-            $tests = @(Get-ChildItem -Path tests -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
+            $tests = @(Get-ChildItem -Path tests -Recurse -Filter '*Test*.csproj' -ErrorAction SilentlyContinue)
 
             if ($tests.Count -eq 0) {
               Write-Host "::notice::No test projects found under tests/ - skipping Stryker run."

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -11,9 +11,12 @@
 #   releases without burning CI time on every PR (mutation testing is slow)
 #
 # Stryker discovers each test project's mutation targets via the standard
-# project-reference graph. If a repo wants to tune the run (excluded files,
-# specific mutators, etc.) drop a stryker-config.json next to the test
-# project - dotnet stryker picks it up automatically.
+# project-reference graph. Two configuration modes are supported:
+# - Root stryker-config.json (umbrella): if present, runs Stryker once with
+#   the umbrella config and skips per-project runs (avoids duplicate work).
+# - Per-project stryker-config.json (or none): if no root config exists, runs
+#   Stryker once per test project; per-project configs override Stryker's
+#   defaults when present.
 name: Stryker (mutation testing)
 
 on:
@@ -32,6 +35,11 @@ jobs:
     # net4x, so they would silently mutate only the non-Framework TFMs
     # and miss bugs that only reproduce on Framework.
     runs-on: windows-latest
+    # Skip on the template repo itself - it has no test projects, so the
+    # workflow would just no-op every Sunday at 06:00 UTC, wasting a
+    # Windows runner allocation. Matches the same-pattern guard used by
+    # the .NET test-stage jobs in pr.yaml.
+    if: github.repository != 'Chris-Wolfgang/repo-template'
     timeout-minutes: 120
     steps:
       - name: Check out repo
@@ -40,10 +48,19 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
+        # Install every SDK in the canonical test matrix (.NET Core 3.1
+        # through .NET 10.0). Stryker has to be able to build whichever
+        # TFM each test project targets; pinning to a subset would
+        # silently fail repos that target older runtimes.
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
             8.0.x
+            9.0.x
             10.0.x
 
       - name: Install dotnet-stryker
@@ -54,44 +71,49 @@ jobs:
             dotnet tool install -g dotnet-stryker
           }
 
-      - name: Run Stryker against every test project
+      - name: Run Stryker
         shell: pwsh
         run: |
-          # Canonical behavior: no stryker-config.json gate. Stryker runs
-          # against every test project under tests/ using dotnet stryker
-          # defaults; a per-project stryker-config.json overrides those
-          # defaults if present.
-          $tests = @(Get-ChildItem -Path tests -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
-
-          if ($tests.Count -eq 0) {
-            Write-Host "::notice::No test projects found under tests/ - skipping Stryker run."
-            exit 0
-          }
-
-          Write-Host "Found $($tests.Count) test project(s):"
-          $tests | ForEach-Object { Write-Host "  $($_.FullName)" }
-          Write-Host ""
+          # Configuration mode resolution:
+          #   1. If a root stryker-config.json exists, it is the umbrella -
+          #      run Stryker once with it and stop (per-project runs would
+          #      duplicate the same work the umbrella already covers).
+          #   2. Otherwise, run Stryker against every test project under
+          #      tests/. A per-project stryker-config.json next to a test
+          #      project overrides Stryker's defaults when present.
 
           $failed = 0
-          foreach ($proj in $tests) {
-            $dir = $proj.DirectoryName
-            Write-Host "::group::Stryker in $dir"
-            Push-Location $dir
-            try {
-              dotnet stryker
-              if ($LASTEXITCODE -ne 0) { $failed++ }
-            } finally {
-              Pop-Location
-            }
-            Write-Host "::endgroup::"
-          }
 
-          # Also honor a root-level umbrella config if the repo provides one
           if (Test-Path 'stryker-config.json') {
-            Write-Host "::group::Stryker with root stryker-config.json"
+            Write-Host "::group::Stryker with root umbrella stryker-config.json"
             dotnet stryker --config-file stryker-config.json
             if ($LASTEXITCODE -ne 0) { $failed++ }
             Write-Host "::endgroup::"
+          }
+          else {
+            $tests = @(Get-ChildItem -Path tests -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
+
+            if ($tests.Count -eq 0) {
+              Write-Host "::notice::No test projects found under tests/ - skipping Stryker run."
+              exit 0
+            }
+
+            Write-Host "Found $($tests.Count) test project(s):"
+            $tests | ForEach-Object { Write-Host "  $($_.FullName)" }
+            Write-Host ""
+
+            foreach ($proj in $tests) {
+              $dir = $proj.DirectoryName
+              Write-Host "::group::Stryker in $dir"
+              Push-Location $dir
+              try {
+                dotnet stryker
+                if ($LASTEXITCODE -ne 0) { $failed++ }
+              } finally {
+                Pop-Location
+              }
+              Write-Host "::endgroup::"
+            }
           }
 
           if ($failed -gt 0) {

--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -310,7 +310,7 @@ TFMs, which only build on Windows; a Linux runner would silently mutate
 only the .NET (Core) TFMs and miss any bugs that reproduce only on
 Framework.
 
-**The workflow always runs** - no opt-in is required.
+**No opt-in is required** - Stryker runs without a `stryker-config.json`. (Triggers are still schedule + manual dispatch only; mutation testing is not a per-PR check.)
 
 Two configuration modes are supported:
 

--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -301,15 +301,28 @@ because they are useful in steady-state:
 | `scripts/format.ps1` | One-shot formatter (CSharpier + analyzer auto-fixups). Mirrors what the CI build expects, so running it locally avoids surprise CI failures. |
 
 
-## Mutation Testing (Optional)
+## Mutation Testing
 
-`.github/workflows/stryker.yaml` provides a Stryker.NET mutation-testing
-workflow. The workflow runs on demand only (`workflow_dispatch`). To enable
-for your repo, drop a `stryker-config.json` next to your test project; the
-workflow picks it up automatically. Per-repo enablement is a separate
-decision - the canonical workflow lives in the template so every repo can
-opt in without re-deriving the YAML.
+`.github/workflows/stryker.yaml` runs Stryker.NET mutation testing against
+every test project under `tests/` on a **Windows** runner. Windows is
+required because the test matrix can include .NET Framework 4.6.2-4.8.1
+TFMs, which only build on Windows; a Linux runner would silently mutate
+only the .NET (Core) TFMs and miss any bugs that reproduce only on
+Framework.
 
-Mutation testing is expensive (it re-runs the suite once per mutated source
-line). Run it ad-hoc when you want a sanity check on test-suite quality;
-do not gate every PR on it.
+**The workflow always runs** - no opt-in is required. Stryker discovers
+each test project automatically; if you want to tune the run for a
+specific repo (excluded files, specific mutators, mutation level, etc.),
+drop a `stryker-config.json` next to the test project and `dotnet stryker`
+will pick it up.
+
+Triggers:
+
+- `workflow_dispatch` - manual ad-hoc runs (e.g. while iterating on tests)
+- `schedule` - weekly Sunday 06:00 UTC; catches quality regressions between
+  releases without burning CI time on every PR (mutation testing is slow)
+
+The Stryker HTML report is uploaded as a workflow artifact
+(`stryker-report-<run-id>`) and retained for 30 days. Download it from the
+workflow run page to see per-mutator survival rates and the surviving
+mutant locations.

--- a/REPO-INSTRUCTIONS.md
+++ b/REPO-INSTRUCTIONS.md
@@ -310,11 +310,18 @@ TFMs, which only build on Windows; a Linux runner would silently mutate
 only the .NET (Core) TFMs and miss any bugs that reproduce only on
 Framework.
 
-**The workflow always runs** - no opt-in is required. Stryker discovers
-each test project automatically; if you want to tune the run for a
-specific repo (excluded files, specific mutators, mutation level, etc.),
-drop a `stryker-config.json` next to the test project and `dotnet stryker`
-will pick it up.
+**The workflow always runs** - no opt-in is required.
+
+Two configuration modes are supported:
+
+- **Root-level umbrella** - if a `stryker-config.json` exists at the repo
+  root, it is treated as the umbrella config: Stryker is invoked once with
+  it and per-project runs are skipped (avoids duplicating the same work).
+  Use this when one Stryker invocation should cover multiple test projects.
+- **Per-project (default)** - if no root config exists, Stryker runs once
+  per test project under `tests/`. A per-project `stryker-config.json` next
+  to a test project overrides Stryker's defaults (excluded files, specific
+  mutators, mutation level, etc.).
 
 Triggers:
 


### PR DESCRIPTION
## Summary

Reworks `.github/workflows/stryker.yaml` so it (a) runs on **Windows** instead of Linux, and (b) always runs - no `stryker-config.json` gate.

## Why

- **Windows runner**: the canonical test matrix targets .NET 5.0-10.0 **and** .NET Framework 4.6.2-4.8.1. Linux runners cannot build .NET Framework targets, so a Linux-hosted Stryker run silently mutates only the non-Framework TFMs and misses any bug that only reproduces on Framework. Switching to `windows-latest` lets Stryker compile every TFM the repo targets.

- **Drop the config-file gate**: the previous workflow short-circuited to a no-op when `stryker-config.json` was absent, making mutation testing effectively opt-in per repo. Per the new canonical behavior, Stryker runs by default against every test project under `tests/`. A repo can still drop a `stryker-config.json` next to a test project to override Stryker's defaults (excluded files, specific mutators, etc.) - `dotnet stryker` picks it up automatically.

## What changed

| File | Change |
|---|---|
| `.github/workflows/stryker.yaml` | `runs-on: ubuntu-latest` -> `windows-latest`; dropped the `Detect stryker-config.json` step; `Run Stryker` step now iterates every `tests/**/*.csproj` and runs `dotnet stryker` from the test project directory; a root-level `stryker-config.json` is still honored as an umbrella config. Bumped `timeout-minutes` from 60 to 120 to absorb the Framework-target build cost. |
| `REPO-INSTRUCTIONS.md` | Rewrote the **Mutation Testing** section: explicitly notes Windows runner is required for the Framework TFMs, explains the no-opt-in behavior, lists triggers, and describes the `stryker-report-<run-id>` artifact. |

## Triggers (unchanged)

- `workflow_dispatch` - manual ad-hoc
- `schedule: '0 6 * * 0'` - weekly Sunday 06:00 UTC

Mutation testing is still too slow to gate every PR; the schedule + dispatch model is preserved.

## Downstream propagation

After this lands, the `stryker.yaml` change should be propagated to all downstream repos that already have a copy (mainly the ones that came through the C1+T3 canonical-protected wave). That's a separate fan-out PR set via the `bulk-repo-pr` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)