### PR TITLE
Fix DOCFX-VERSION-PICKER deploy-flow diagram (feed-back from ICollection-Extensions #158)

### DIFF
--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -114,17 +114,28 @@ canonical version-selector UI.
 
 ## How it gets to gh-pages
 
+`docfx.yaml` is **not** triggered directly by `push` or by pushing a
+tag — it has only `workflow_call` (invoked by `release.yaml` after a
+GitHub Release is published) and `workflow_dispatch` (manual). So
+the actual chain that deploys the picker is:
+
 ```
-push to main / release tag
-  └─ docfx.yaml fires
-       ├─ docfx build  → _site/  (includes public/version-picker.js,
-       │                          inline bootstrap in every page's
-       │                          footer via _appFooter)
-       ├─ Generate versions.json from v* tags → _site/versions.json
-       ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
-       └─ Generate root index.html from version-picker-template.html
-                  → deploy to gh-pages /
+GitHub Release published   (or manual workflow_dispatch)
+  └─ release.yaml fires    (only on the published-release flow)
+       └─ release.yaml → calls docfx.yaml as a reusable workflow
+            └─ docfx.yaml fires
+                 ├─ docfx build  → _site/  (includes public/version-picker.js,
+                 │                          inline bootstrap in every page's
+                 │                          footer via _appFooter)
+                 ├─ Generate versions.json from v* tags → _site/versions.json
+                 ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
+                 └─ Generate root index.html from version-picker-template.html
+                            → deploy to gh-pages /
 ```
+
+A plain `git push` to `main` does **not** redeploy the docs — the
+gh-pages content updates only when a GitHub Release is published
+(or when someone runs `docfx.yaml` manually via the Actions tab).
 
 Result on gh-pages:
 

--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -116,26 +116,33 @@ canonical version-selector UI.
 
 `docfx.yaml` is **not** triggered directly by `push` or by pushing a
 tag — it has only `workflow_call` (invoked by `release.yaml` after a
-GitHub Release is published) and `workflow_dispatch` (manual). So
-the actual chain that deploys the picker is:
+GitHub Release is published) and `workflow_dispatch` (manual). Two
+paths reach it:
 
 ```
-GitHub Release published   (or manual workflow_dispatch)
-  └─ release.yaml fires    (only on the published-release flow)
+Path 1 — normal: a GitHub Release is published
+  └─ release.yaml fires (on `release: types: [published]`)
        └─ release.yaml → calls docfx.yaml as a reusable workflow
-            └─ docfx.yaml fires
-                 ├─ docfx build  → _site/  (includes public/version-picker.js,
-                 │                          inline bootstrap in every page's
-                 │                          footer via _appFooter)
-                 ├─ Generate versions.json from v* tags → _site/versions.json
-                 ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
-                 └─ Generate root index.html from version-picker-template.html
-                            → deploy to gh-pages /
+            └─ docfx.yaml runs the deploy steps below
+
+Path 2 — manual: a maintainer runs docfx.yaml from the Actions tab
+  └─ docfx.yaml fires directly (on `workflow_dispatch`)
+       └─ docfx.yaml runs the deploy steps below
+
+The deploy steps that docfx.yaml runs in both cases:
+  ├─ docfx build  → _site/  (includes public/version-picker.js,
+  │                          inline bootstrap in every page's
+  │                          footer via _appFooter)
+  ├─ Generate versions.json from v* tags → _site/versions.json
+  ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
+  └─ Generate root index.html from version-picker-template.html
+             → deploy to gh-pages /
 ```
 
 A plain `git push` to `main` does **not** redeploy the docs — the
-gh-pages content updates only when a GitHub Release is published
-(or when someone runs `docfx.yaml` manually via the Actions tab).
+gh-pages content updates only via Path 1 (publishing a GitHub
+Release) or Path 2 (manually running `docfx.yaml` from the Actions
+tab).
 
 Result on gh-pages:
 


### PR DESCRIPTION
## Summary

The "How it gets to gh-pages" section of `docs/DOCFX-VERSION-PICKER.md`
claimed `push to main / release tag → docfx.yaml fires`. That's
inaccurate — `docfx.yaml` has only `workflow_call` (invoked by
`release.yaml` after a GitHub Release is published) and
`workflow_dispatch` (manual) triggers. A plain `git push` to `main`
does **not** redeploy the docs.

Anyone trying to understand why their picker change didn't appear
after pushing to main would be misled by the original diagram.

## Fix

Replaced the simplified flow with the actual chain:

```
GitHub Release published   (or manual workflow_dispatch)
  └─ release.yaml fires    (only on the published-release flow)
       └─ release.yaml → calls docfx.yaml as a reusable workflow
            └─ docfx.yaml fires
                 ├─ docfx build  → _site/
                 ├─ Generate versions.json from v* tags
                 ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
                 └─ Generate root index.html from version-picker-template.html
```

And added an explicit standalone note so the no-redeploy-on-push
behavior is unmissable:

> A plain `git push` to `main` does **not** redeploy the docs — the
> gh-pages content updates only when a GitHub Release is published
> (or when someone runs `docfx.yaml` manually via the Actions tab).

## How this was discovered

Caught during the Copilot review on **ICollection-Extensions PR #158**
where the doc was first being synced from the canonical. Fixed there
in commit `9b1b3d0` and shipped in
[Wolfgang.Extensions.ICollection v0.3.1](https://github.com/Chris-Wolfgang/ICollection-Extensions/releases/tag/v0.3.1).

This PR brings the fix back to repo-template so the next template
sync propagates it to every downstream — saving the same Copilot
finding from firing on every per-repo picker-doc sync going forward.

## Other downstream repos with the doc

Repos that already have `docs/DOCFX-VERSION-PICKER.md` with the
incorrect diagram will need a one-line drift cleanup on their next
canonical sweep. Tracked via a follow-up `template-drift-scan` after
this lands.