### PR TITLE
Feed-back: version-picker.js hardening + build-pr.ps1 fixes (from ICollection-Extensions)

### DIFF
--- a/docfx_project/public/version-picker.js
+++ b/docfx_project/public/version-picker.js
@@ -117,16 +117,32 @@
         select.addEventListener('change', function (e) {
             var target = e.target.value;
             if (!target) return;
+
+            // Defensive: refuse to navigate to non-http(s) schemes. The
+            // value comes from versions.json — a compromised or malicious
+            // file could try to slip in `javascript:`/`data:` to run code
+            // in the docs origin. Only allow root-relative paths or
+            // explicit http(s) absolute URLs.
+            if (!/^(?:\/[^\/]|https?:\/\/)/i.test(target)) {
+                return;
+            }
+
             // versions.json's `url` fields include the gh-pages repo prefix
             // (e.g. /DateTime-Extensions/versions/v1.2.0/) because that's
             // the correct absolute path on github.io. On localhost or on a
             // CNAME-served custom domain, that prefix isn't a directory
-            // and the navigation 404s. Strip the first path segment when
-            // we're not on github.io so the URL becomes relative to the
-            // actual document root.
-            if (!window.location.hostname.endsWith('.github.io') && target.charAt(0) === '/') {
-                target = target.replace(/^\/[^\/]+\//, '/');
+            // and the navigation 404s. Strip the first path segment only
+            // when (a) we're not on github.io AND (b) the current page's
+            // pathname doesn't already start with that same prefix —
+            // otherwise we'd break navigation on a CNAME setup that DOES
+            // serve `/<prefix>/...`.
+            if (target.charAt(0) === '/' && !window.location.hostname.endsWith('.github.io')) {
+                var firstSeg = target.match(/^(\/[^\/]+)\//);
+                if (firstSeg && !window.location.pathname.startsWith(firstSeg[1] + '/')) {
+                    target = target.replace(/^\/[^\/]+\//, '/');
+                }
             }
+
             window.location.href = target;
         });
 

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -84,7 +84,17 @@ if (-not $SkipTests -and $failed.Count -eq 0) {
     $testProjects = @(Get-ChildItem -Path './tests' -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' -ErrorAction SilentlyContinue)
 
     if ($testProjects.Count -eq 0) {
-        Write-Host "No test projects found in ./tests — skipping"
+        # If ./src has projects, fail — silent skip would diverge from CI's
+        # strict gate. If neither ./src nor ./tests has projects (template-pack
+        # / in-dev repos), the skip is legitimate.
+        $srcHasProjects = @(Get-ChildItem -Path './src' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' -ErrorAction SilentlyContinue).Count -gt 0
+        if ($srcHasProjects) {
+            Write-Fail "./tests has no test projects but ./src contains projects — refusing to silently skip the coverage gate."
+            $failed += "Tests"
+        }
+        else {
+            Write-Host "No test projects found in ./tests and no ./src projects — skipping (template-pack / in-dev shape)."
+        }
     }
     else {
         foreach ($testProj in $testProjects) {
@@ -218,7 +228,11 @@ if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
             }
         }
         else {
-            Write-Host "Coverage report not generated — skipping threshold check"
+            # Diverged from pr.yaml behavior in the past — that would let a local
+            # "All checks passed" silently hide ReportGenerator failures while CI
+            # rejected the same situation. Fail loudly here too, so local matches CI.
+            Write-Fail "Coverage report not generated (CoverageReport/Summary.txt missing) — ReportGenerator likely failed."
+            $failed += "Coverage"
         }
     }
 }
@@ -283,7 +297,19 @@ if (-not $SkipSecurity) {
         else {
             $archive = "gitleaks_${version}_linux_x64.tar.gz"
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
-            curl -sSfL $url | tar xz -C /usr/local/bin gitleaks
+            # Install to a user-writable location instead of /usr/local/bin
+            # (which would require sudo for most local dev shells). $HOME/.local/bin
+            # is on PATH by default on most Linux distros and macOS; if not, prepend it.
+            $localBin = Join-Path $HOME ".local/bin"
+            New-Item -ItemType Directory -Force -Path $localBin | Out-Null
+            # Use 'tar -f -' so extraction reads the gitleaks archive from
+            # stdin. GNU tar without '-f' defaults to /dev/tape (or another
+            # default depending on the TAPE env var), which can hang silently
+            # in CI / fresh shells.
+            curl -sSfL $url | tar -xz -f - -C $localBin gitleaks
+            if (-not ($env:PATH -split [IO.Path]::PathSeparator | Where-Object { $_ -eq $localBin })) {
+                $env:PATH = "$localBin$([IO.Path]::PathSeparator)$env:PATH"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Two files with clear universal improvements that have been running on
ICollection-Extensions and shipping cleanly through its recent
releases (v0.2.0 → v0.3.0 → v0.3.1). Both apply to every fleet repo
with no repo-specific behavior, so they belong in the canonical.

## `docfx_project/public/version-picker.js` (+21 / -5 lines)

### Security: refuse non-http(s) navigation schemes

The picker's navigation target comes from `versions.json`. Without a
scheme guard, a compromised or malicious `versions.json` could slip
in `javascript:` to run arbitrary code in the docs origin. The new
guard accepts only root-relative paths or explicit `http(s)://`
absolute URLs:

```js
if (!/^(?:\/[^\/]|https?:\/\/)/i.test(target)) {
    return;
}
```

### CNAME path-prefix bug fix

The original always stripped the first path segment when not on
`*.github.io`. That breaks navigation on a CNAME-served custom-domain
site whose pathname *does* start with `/<repo>/` (some sites do
preserve the gh-pages prefix even on CNAME).

The improved version checks whether the current page's pathname
already starts with that segment before stripping:

```js
if (target.charAt(0) === '/' && !window.location.hostname.endsWith('.github.io')) {
    var firstSeg = target.match(/^(\/[^\/]+)\//);
    if (firstSeg && !window.location.pathname.startsWith(firstSeg[1] + '/')) {
        target = target.replace(/^\/[^\/]+\//, '/');
    }
}
```

## `scripts/build-pr.ps1` (+29 / -3 lines)

### Strict tests-projects gate

If `./tests` has no projects but `./src` DOES have projects, fail
loudly instead of silently skipping the coverage gate. Local was
diverging from `pr.yaml`'s strict gate; this matches them.

Still skips legitimately for template-pack / in-dev repos with
neither `./src` nor `./tests` projects.

### Coverage report missing → fail

When `CoverageReport/Summary.txt` is missing, fail loudly. Previously
a silent skip — local "All checks passed" could hide ReportGenerator
failures while CI rejected the same state. This was a real local-CI
divergence.

### gitleaks install: user-local + stdin tar

- Install to `$HOME/.local/bin` instead of `/usr/local/bin` so no
  sudo is needed in local dev shells. `$HOME/.local/bin` is on
  `PATH` by default on most Linux distros and macOS; if not, the
  script prepends it.
- Switched `tar xz` to `tar -xz -f -` so the archive is read from
  stdin explicitly. Without `-f`, GNU tar defaults to `/dev/tape`
  (or whatever `$TAPE` is set to) and can hang silently in fresh
  shells.

## Origin

Discovered during the canonical drift scan on ICollection-Extensions
after the v0.3.1 release shipped. ICollection had been running with
these improvements for some time without anyone propagating them
back to repo-template. This PR brings the improvements upstream so
the rest of the fleet inherits them on the next template sync.

## Related

- ICollection-Extensions PR #160 — forward-sync of the workflow files
  that template was ahead on (the reverse drift direction)
- repo-template PR #402 — feed-back of the `DOCFX-VERSION-PICKER.md`
  diagram fix (same scan, different file)