### PR TITLE
Bump stale analyzer pins in Directory.Build.props (Meziantou, SourceLink, Sonar)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,13 +54,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.98">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -105,7 +105,7 @@
   <ItemGroup>
     <!-- SourceLink: embed source provenance into PDBs so debuggers can step
          into NuGet package code from GitHub. -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
## Summary

`Directory.Build.props` in repo-template has been frozen on older analyzer versions while every active fleet repo has bumped via Dependabot. Bringing the canonical up to the fleet's current state.

## Drift

| Package | Template (was) | Fleet (now) |
|---|---|---|
| `Meziantou.Analyzer` | 3.0.58 | 3.0.98 |
| `Microsoft.SourceLink.GitHub` | 8.0.0 | 10.0.300 |
| `SonarAnalyzer.CSharp` | 10.25.0.139117 | 10.27.0.140913 |

## Fleet convergence check

| Repo | Meziantou | SourceLink | Sonar |
|---|---|---|---|
| repo-template (was) | 3.0.58 | 8.0.0 | 10.25.0.139117 |
| DateTime-Extensions | **3.0.98** | **10.0.300** | **10.27.0.140913** |
| DbContextBuilder | **3.0.98** | **10.0.300** | **10.27.0.140913** |
| IEnumerable-Extensions | **3.0.98** | **10.0.300** | **10.27.0.140913** |
| IEquatable-Extensions | **3.0.98** | 8.0.0 ⚠ | **10.27.0.140913** |
| ICollection-Extensions | **3.0.98** | **10.0.300** | **10.27.0.140913** |

All 5 active fleet repos are at the new Meziantou + Sonar versions. 4 of 5 are at the new SourceLink (IEquatable still on 8.0.0 — its own pending cleanup, tracked separately).

## Why this matters

Without this bump:
- New fleet repos created from the template get stale analyzer versions on day one
- `template-drift-scan` flags `Directory.Build.props` as systemic spurious diff on every existing repo (3 separate version pins show up as drift even though the rest of the file is in sync)
- Dependabot bumps that have already landed downstream get re-flagged as "drift" each scan

## Discovery

Found during the canonical drift sweep on ICollection-Extensions after v0.3.1 shipped. Companion to:
- ICollection #160 (forward-sync 9 canonical files)
- ICollection #161 (`.gitignore` forward-sync)
- repo-template #402 (`DOCFX-VERSION-PICKER.md` diagram fix)
- repo-template #403 (`version-picker.js` + `build-pr.ps1` improvements)
- repo-template #404 (canonical `benchmarks.yaml` workflow)