### PR TITLE
Fix DOCFX-VERSION-PICKER diagram: deploy_as_latest-conditional steps (feed-back from #162)

### DIFF
--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -134,15 +134,28 @@ The deploy steps that docfx.yaml runs in both cases:
   │                          inline bootstrap in every page's
   │                          footer via _appFooter)
   ├─ Generate versions.json from v* tags → _site/versions.json
-  ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
+  ├─ Deploy _site/ to gh-pages /versions/<v>/  (always)
+  │
+  │  --- The remaining two steps only run when `deploy_as_latest`
+  │      is true (the default; uncheck on workflow_dispatch when
+  │      you're rebuilding an OLDER version and don't want to move
+  │      the "latest" alias):
+  │
+  ├─ Deploy _site/ to gh-pages /versions/latest/   [deploy_as_latest only]
   └─ Generate root index.html from version-picker-template.html
-             → deploy to gh-pages /
+             → deploy to gh-pages /                [deploy_as_latest only]
 ```
 
 A plain `git push` to `main` does **not** redeploy the docs — the
 gh-pages content updates only via Path 1 (publishing a GitHub
 Release) or Path 2 (manually running `docfx.yaml` from the Actions
 tab).
+
+`deploy_as_latest` defaults to true. The escape hatch is for the
+Path 2 manual case where you want to rebuild and republish the
+docs for an older version (e.g. backporting a doc fix to `v1.0.0`)
+without overwriting the `/versions/latest/` alias and the site-root
+index that the picker bootstrap reads.
 
 Result on gh-pages:
 

--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -155,7 +155,8 @@ tab).
 Path 2 manual case where you want to rebuild and republish the
 docs for an older version (e.g. backporting a doc fix to `v1.0.0`)
 without overwriting the `/versions/latest/` alias and the site-root
-index that the picker bootstrap reads.
+`index.html` (which loads the picker bootstrap; the picker JS itself
+reads `versions.json` for the version list).
 
 Result on gh-pages:
 


### PR DESCRIPTION
## Summary

The 'How it gets to gh-pages' diagram in `docs/DOCFX-VERSION-PICKER.md`
showed two steps as unconditional that are actually gated on
`inputs.deploy_as_latest != false`:

1. `Deploy _site/ to gh-pages /versions/latest/`
2. `Generate root index.html from version-picker-template.html`

In `docfx.yaml` (line 344):

```yaml
if: inputs.deploy_to_pages != false && inputs.deploy_as_latest != false
```

The escape hatch exists for the Path 2 (manual `workflow_dispatch`)
case where you're republishing an OLDER version — e.g. backporting
a doc fix to `v1.0.0` — and don't want to move the `/versions/latest/`
alias or rewrite the site-root index that the picker bootstrap reads.

## Fix

Marked both steps `[deploy_as_latest only]` in the diagram and added
a follow-on paragraph documenting:
- `deploy_as_latest` defaults to `true`
- The rebuild-older-version use case for unchecking it

## How this was discovered

Caught during Copilot review on **ICollection-Extensions PR #162**
where the doc had the same error after the [#402 two-path diagram
correction](https://github.com/Chris-Wolfgang/repo-template/pull/402)
synced through. Fixed there in commit `2d68f15`. Bringing it back to
repo-template so the rest of the fleet inherits the refinement on
the next template sync.

## Iteration history of this diagram

1. **Original** (pre-#402): single chain implied push-to-main triggered
   `docfx.yaml` — that triggers don't exist.
2. **PR #402**: split the two trigger paths (Release published vs
   workflow_dispatch) into Path 1 / Path 2, factored shared deploy
   steps below.
3. **This PR**: refines the shared deploy-steps block to show the
   `deploy_as_latest` gate on the last two steps.

Each iteration was a Copilot review surfacing a real inaccuracy.

## Fleet propagation

Downstream repos (DateTime-Extensions, IEnumerable-Extensions,
IEquatable-Extensions, DbContextBuilder) all have the doc with both
prior versions of the bug. After this lands the next
`template-drift-scan` will flag them for a per-repo sync.