### PR TITLE
setup.ps1: add bootstrap re-run guard + safer README swap

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -224,6 +224,30 @@ function Start-Setup {
     # Ensure we're in the repository root
     Set-RepositoryRoot
     
+    # Bootstrap re-run guard: setup.ps1 is a one-time orchestrator. On first
+    # run it renames README-TEMPLATE.md -> README.md and substitutes a bunch
+    # of placeholders. If README-TEMPLATE.md is gone, the repo is already
+    # bootstrapped - re-running would do nothing useful at best and destroy
+    # the customized README at worst (see the bug fixed in this commit:
+    # Remove-Item README.md happened before the existence check for
+    # README-TEMPLATE.md, so a re-run on a bootstrapped repo left the repo
+    # with no README).
+    if (-not (Test-Path 'README-TEMPLATE.md')) {
+        Write-Host ""
+        Write-TemplateError "This repository appears to already be set up."
+        Write-Host "  README-TEMPLATE.md was not found in the repo root - that is the" -ForegroundColor Yellow
+        Write-Host "  marker setup.ps1 renames to README.md on first run, so its absence" -ForegroundColor Yellow
+        Write-Host "  is the canonical signal that bootstrap is complete." -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "  setup.ps1 is a one-time bootstrap and is not safe to re-run on a" -ForegroundColor Yellow
+        Write-Host "  configured repo. If you genuinely need to re-bootstrap, restore" -ForegroundColor Yellow
+        Write-Host "  README-TEMPLATE.md (and any other deleted template files) from" -ForegroundColor Yellow
+        Write-Host "  Chris-Wolfgang/repo-template before re-running." -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "  Otherwise, delete this script: scripts/setup.ps1" -ForegroundColor Cyan
+        exit 1
+    }
+    
     Write-Info "This script will configure your new repository."
     Write-Info "It will prompt you for project information and replace all placeholders."
     Write-Host ""
@@ -477,19 +501,27 @@ function Start-Setup {
     
     # Step 1: README swap
     Write-Info "Step 1/${totalSteps}: Swapping README files..."
+    
+    # Verify README-TEMPLATE.md exists BEFORE deleting README.md. The
+    # original code deleted first and only then checked, which left the
+    # repo with NO README at all when README-TEMPLATE.md was missing
+    # (e.g. on a re-run of an already-bootstrapped repo). The re-run
+    # guard at the top of Start-Setup catches the obvious case; this
+    # is defense in depth.
+    if (-not (Test-Path 'README-TEMPLATE.md')) {
+        Write-TemplateError "README-TEMPLATE.md not found - cannot safely swap READMEs."
+        Write-Host "  Restore README-TEMPLATE.md from Chris-Wolfgang/repo-template before" -ForegroundColor Yellow
+        Write-Host "  re-running, or delete scripts/setup.ps1 if the repo is already set up." -ForegroundColor Yellow
+        exit 1
+    }
+    
     if (Test-Path 'README.md') {
         Remove-Item 'README.md' -Force
         Write-Success "Deleted template README.md"
     }
     
-    if (Test-Path 'README-TEMPLATE.md') {
-        Rename-Item 'README-TEMPLATE.md' 'README.md'
-        Write-Success "Renamed README-TEMPLATE.md → README.md"
-    }
-    else {
-        Write-Error "README-TEMPLATE.md not found!"
-        exit 1
-    }
+    Rename-Item 'README-TEMPLATE.md' 'README.md'
+    Write-Success "Renamed README-TEMPLATE.md to README.md"
     
     # Step 2: Replace placeholders
     Write-Info "Step 2/${totalSteps}: Replacing placeholders in files..."


### PR DESCRIPTION
## Summary

Fixes two real bugs in `scripts/setup.ps1` that bit `personal-finance-modeler` today (re-ran setup.ps1 on an already-bootstrapped repo and lost README.md).

## The bugs

### 1. README swap deleted README.md *before* checking README-TEMPLATE.md exists

```pwsh
# Old code:
if (Test-Path 'README.md') {
    Remove-Item 'README.md' -Force         # <- deletes first
}
if (Test-Path 'README-TEMPLATE.md') {
    Rename-Item ... 'README.md'
}
else {
    Write-Error "README-TEMPLATE.md not found!"
    exit 1                                 # <- repo now has NO README
}
```

On a re-run where `README-TEMPLATE.md` had already been renamed in a prior bootstrap, the script deleted the customized `README.md` and then errored out, leaving the repo with no README file at all.

**Fix:** verify `README-TEMPLATE.md` exists BEFORE deleting `README.md`.

### 2. No detection that the repo is already bootstrapped

`setup.ps1` is a one-time orchestrator (renames `README-TEMPLATE.md` -> `README.md`, substitutes placeholders, picks a license, deletes non-chosen license variants). Re-running it on a configured repo is destructive at worst and wasteful at best.

**Fix:** at the top of `Start-Setup`, check if `README-TEMPLATE.md` exists. If not, the repo is already bootstrapped - print a clear "this is one-time, here is what to do" message and exit. The check uses the existence of `README-TEMPLATE.md` as the canonical signal because that is literally what setup.ps1 renames on first run; its absence is the most reliable bootstrap-complete marker.

## How this was discovered

User re-ran `setup.ps1` on `personal-finance-modeler` (a repo bootstrapped a while ago, where `setup.ps1` was never self-deleted). The script deleted `README.md` and then errored out trying to find `README-TEMPLATE.md`. Recovery was `git restore README.md` (still uncommitted, no permanent damage). This PR makes that scenario fail safely up front with a clear message.

## Downstream propagation

After this lands, the new `setup.ps1` should be fanned out to every downstream repo that still has a copy (~18 of them per the prior scan). Those repos already ran setup once, so the new re-run guard would immediately abort - which is exactly the desired behaviour. Better still: those repos can just `git rm scripts/setup.ps1` since it is a one-time script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)