### PR TITLE
fix(build-pr): restore -UseBasicParsing on Invoke-WebRequest

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -289,7 +289,10 @@ if (-not $SkipSecurity) {
             $dest = Join-Path $env:LOCALAPPDATA "gitleaks"
             New-Item -ItemType Directory -Force -Path $dest | Out-Null
             $zip = Join-Path $env:TEMP $archive
-            Invoke-WebRequest -Uri $url -OutFile $zip
+            # -UseBasicParsing: required on Windows PowerShell 5.1, where the
+            # default parser uses the IE engine and throws on stock/minimal
+            # Windows installs. PowerShell 7+ accepts it as a no-op.
+            Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
             Expand-Archive -Path $zip -DestinationPath $dest -Force
             Remove-Item $zip -ErrorAction SilentlyContinue
             $env:PATH = "$dest;$env:PATH"


### PR DESCRIPTION
## Summary

Restores `-UseBasicParsing` on the `Invoke-WebRequest` call in the Windows branch of `scripts/build-pr.ps1`'s gitleaks auto-installer.

On **Windows PowerShell 5.1**, `Invoke-WebRequest` without `-UseBasicParsing` uses the legacy IE-based parser and throws *"the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete"* on stock/minimal Windows. The Windows branch is reachable from PS 5.1 (entered via the `$env:OS -match 'Windows'` half of the guard — `$IsWindows` is a PS7+ automatic variable that's `$null` on 5.1), so a contributor on 5.1 without gitleaks installed hits the error. PowerShell 7+ accepts the switch as a no-op → works on both hosts at zero cost.

## Why canonical (not per-repo)

Surfaced by Copilot on **ETL-FixedWidth**'s v0.2.2 release PR (#134). The line is **byte-identical across `repo-template`, DateTime-Extensions, and ETL-Json** — it isn't an ETL-FixedWidth bug. Fixing it here so it can sync to the fleet, rather than diverging a single repo on its release.

## Follow-up

Fan out to downstream repos via the standard `template-sync` / `bulk-repo-pr` flow.