### PR TITLE
fix(analyzers): scope PublicApiAnalyzers package to opt-in projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -74,7 +74,7 @@
          Library projects under src/ should opt in; test / example /
          benchmark projects should not. Per-repo enablement is tracked as a
          follow-up maintenance issue. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" Condition="Exists('PublicAPI.Shipped.txt') or Exists('PublicAPI.Unshipped.txt')">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Scopes the `Microsoft.CodeAnalysis.PublicApiAnalyzers` `PackageReference` so it's only referenced by projects that actually use it.

It was **unconditional**, so the analyzer was restored and loaded into *every* project (test, example, benchmark) — but only the `AdditionalFiles` (gated by `Exists('PublicAPI.Shipped.txt')` / `...Unshipped.txt`) decide whether it emits diagnostics. So non-library projects paid the restore + analyzer-load cost for zero output, contradicting the block's own comment ("library projects under `src/` should opt in; test/example/benchmark should not").

Fix: add `Condition="Exists('PublicAPI.Shipped.txt') or Exists('PublicAPI.Unshipped.txt')"` to the `PackageReference`, matching the existing `AdditionalFiles` gating.

## Why canonical (not per-repo)

Surfaced by Copilot on **ETL-FixedWidth**'s v0.2.2 release PR (#134). The block is identical across `repo-template`, DateTime-Extensions, and ETL-Json — not an ETL-FixedWidth bug. Fixing here for fleet sync.

## Follow-up

Fan out via `template-sync` / `bulk-repo-pr`.