### PR TITLE
fix(docfx): don't fail first deploy when gh-pages serves a 200 placeholder

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -385,12 +385,30 @@ jobs:
             Write-Error "Failed to fetch existing versions.json at $existingUrl (status=$statusCode): $($_.Exception.Message). Refusing to deploy - a transient fetch failure must not be treated as a first deploy because that path can wipe previously-published version entries."
             exit 1
           }
+          # Parse the newly-generated local manifest first. A failure here is
+          # fatal — it means docfx generation is broken.
           try {
-            $existing = $existingRaw | ConvertFrom-Json
-            $new = Get-Content $newPath -Raw | ConvertFrom-Json
+            $new = Get-Content $newPath -Raw | ConvertFrom-Json -ErrorAction Stop
           } catch {
-            Write-Error "Failed to parse versions.json: $($_.Exception.Message)"
+            Write-Error "Failed to parse newly-generated ${newPath}: $($_.Exception.Message). docfx generation is broken — refusing to deploy."
             exit 1
+          }
+          # The fetch returned HTTP 200, but a freshly-created gh-pages branch
+          # (or a site still propagating its first deploy) can serve a generic
+          # GitHub 404 HTML page with status 200, or otherwise non-JSON content.
+          # Treat an existing body that isn't a parseable versions array the
+          # same as a 404 first deploy — there is no prior manifest to preserve
+          # — rather than aborting the very first deploy that would create
+          # versions.json.
+          try {
+            $existing = $existingRaw | ConvertFrom-Json -ErrorAction Stop
+          } catch {
+            Write-Host "::notice::Existing content at $existingUrl is not valid JSON (likely a 200 placeholder served on first deploy) — treating as first deploy, skipping preservation check."
+            exit 0
+          }
+          if (@($existing | Where-Object { $_.PSObject.Properties.Name -contains 'version' }).Count -eq 0) {
+            Write-Host "::notice::Existing versions.json at $existingUrl has no version entries (not a versions manifest) — treating as first deploy, skipping preservation check."
+            exit 0
           }
           $existingCount = @($existing).Count
           $newCount = @($new).Count


### PR DESCRIPTION
## Summary

The `versions.json` preservation guard in `docfx.yaml` only treated an explicit **HTTP 404** as "first deploy." A brand-new `gh-pages` branch (or a site still propagating its first deploy) can serve a generic GitHub **404 HTML page with status 200**, or other non-JSON content. The fetch then *succeeded*, the shared `ConvertFrom-Json` threw on the HTML, and the step exited 1 with *"Failed to parse versions.json"* — **blocking the very first deploy** that would have created `versions.json`.

## Fix

Split the parse handling:
- **Local** newly-generated manifest is parsed first — failure stays **fatal** (broken docfx generation).
- **Remote** fetched body is parsed separately — if it isn't valid JSON, or parses but has no entries with a `version` property, treat it as a **first deploy** (no prior manifest to preserve) and skip, instead of aborting.

A genuine existing versions array still triggers the preservation comparison unchanged.

### Verified locally
| Input | Result |
|-------|--------|
| `<html>404</html>` (200 placeholder) | notice → skip, exit 0 ✅ (was fatal) |
| `[{"version":"v1"}]` | preservation check runs ✅ |
| `{"message":"Not Found"}` | notice → skip, exit 0 ✅ |

(Parsed via `[Parser]::ParseFile` → PARSE OK. Note: `docfx.yaml` can't be CI-validated on repo-template — its jobs self-skip — so this was checked by extracting the pwsh block.)

## Why canonical

Surfaced by Copilot on **ETL-FixedWidth** v0.2.2 (#134); guard is identical fleet-wide. Fixing here for sync. Fan out via `template-sync`.