### PR TITLE
ci(pr): surface integration-test projects excluded from the coverage gate

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -475,6 +475,14 @@ jobs:
 
           mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -name "*.Tests.Integration.*" -print0)
 
+          # Report any integration test projects deliberately excluded from the
+          # coverage gate, so the skip is visible rather than silent (they are
+          # expected to run in a separate workflow).
+          mapfile -d '' -t excluded_integration < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -name "*.Tests.Integration.*" -print0)
+          if [ ${#excluded_integration[@]} -gt 0 ]; then
+            echo "::notice::Excluded ${#excluded_integration[@]} integration test project(s) from the coverage gate (expected to run in a separate workflow): ${excluded_integration[*]}"
+          fi
+
           if [ ${#test_projects[@]} -eq 0 ]; then
             if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
               echo "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
@@ -1170,6 +1178,14 @@ jobs:
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
           done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -name "*.Tests.Integration.*" -print0)
+
+          # Report any integration test projects deliberately excluded from the
+          # coverage gate, so the skip is visible rather than silent (they are
+          # expected to run in a separate workflow).
+          mapfile -d '' -t excluded_integration < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -name "*.Tests.Integration.*" -print0)
+          if [ ${#excluded_integration[@]} -gt 0 ]; then
+            echo "::notice::Excluded ${#excluded_integration[@]} integration test project(s) from the coverage gate (expected to run in a separate workflow): ${excluded_integration[*]}"
+          fi
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then


### PR DESCRIPTION
## Summary

The coverage-gate test discovery filters out `*.Tests.Integration.*` projects (`-not -name "*.Tests.Integration.*"`), but **silently** — if such a project existed it was dropped from the gate with no log line, inconsistent with the *"refuse to silently skip the coverage gate"* intent of the surrounding code.

Adds a `::notice::` at **both** discovery sites (Linux stage ~line 476, Windows stage ~line 1172) listing any integration projects actually excluded.

### Behavior (verified locally)
| Scenario | Result |
|----------|--------|
| no `*.Tests.Integration.*` project | no notice (silent, correct) |
| an integration project present | `::notice::Excluded 1 integration test project(s)…` |
| unit-project discovery | unchanged — still filters integration out |

**No-op today** — no repo in the fleet has a `*.Tests.Integration.*` project yet, so it only speaks up once one is added. (`build-pr.ps1` has no integration filter to mirror, so nothing to sync there.)

## Why canonical

Surfaced by Copilot on **ETL-FixedWidth** v0.2.2 (#134); filter is identical fleet-wide. Fixing here for sync.