### PR TITLE
ci(pr): fail the macOS coverage gate when 0 modules are parsed

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1265,11 +1265,13 @@ jobs:
 
           THRESHOLD=${CODECOV_MINIMUM:-90}
           FAILED=0
+          MATCHED=0
 
           while IFS= read -r line; do
             if echo "$line" | grep -qE '^[^ ]+.*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
               MODULE=$(echo "$line" | awk '{print $1}')
               PERCENT=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | grep -oE '^[0-9]+')
+              MATCHED=$((MATCHED + 1))
               echo "Checking module: '$MODULE' - Coverage: ${PERCENT}%"
               if [ "$PERCENT" -lt "$THRESHOLD" ]; then
                 echo "  ❌ FAIL: Below ${THRESHOLD}% threshold"
@@ -1279,6 +1281,14 @@ jobs:
               fi
             fi
           done < CoverageReport/Summary.txt
+
+          # Fail loudly when 0 modules matched — the regex is wrong or the
+          # Summary.txt format changed. Silently passing here would make Stage 3
+          # the weak link while Stages 1/2 fail loudly on the same drift.
+          if [ "$MATCHED" -eq 0 ]; then
+            echo "❌ Coverage parser matched 0 modules in Summary.txt — regex or report format is out of sync. Refusing to silently pass the gate."
+            exit 1
+          fi
 
           if [ "$FAILED" -ne 0 ]; then
             echo ""

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -204,10 +204,12 @@ if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
             Write-Host ""
 
             $failedProjects = @()
+            $matched = 0
             foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
                 if ($line -match '^\s*(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^\s*Summary') {
                     $module = $Matches[1]
                     $percent = [int][math]::Floor([double]$Matches[2])
+                    $matched++
 
                     if ($percent -lt $CoverageThreshold) {
                         Write-Fail "  $module — ${percent}% (below ${CoverageThreshold}%)"
@@ -219,7 +221,13 @@ if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
                 }
             }
 
-            if ($failedProjects.Count -gt 0) {
+            if ($matched -eq 0) {
+                # Mirror pr.yaml: a parser/format drift that matches zero modules
+                # must fail loudly, not silently pass the gate.
+                Write-Fail "Coverage parser matched 0 modules in Summary.txt — regex or report format is out of sync. Refusing to silently pass the gate."
+                $failed += "Coverage"
+            }
+            elseif ($failedProjects.Count -gt 0) {
                 Write-Fail "Coverage gate FAILED: $($failedProjects -join ', ')"
                 $failed += "Coverage"
             }


### PR DESCRIPTION
## Summary

Stage 3 (macOS) enforced the coverage threshold with a `FAILED` flag but **no matched-module counter** — so if the `Summary.txt` parser matched **zero rows** (regex drift / ReportGenerator format change), the loop checked nothing, `FAILED` stayed `0`, and the step printed **"COVERAGE GATE PASSED."** Stages 1 (Linux) and 2 (Windows) already fail loudly on this, so **macOS was the weak link** — a format drift would silently pass coverage there.

## Fix

- **`pr.yaml` (macOS step):** count matched modules; `exit 1` with the canonical *"matched 0 modules … refusing to silently pass the gate"* message when none match — same guard Stages 1/2 already have.
- **`scripts/build-pr.ps1`:** the local coverage step had the same silent-pass gap; added the equivalent guard so local matches CI (per the pr.yaml ↔ build-pr.ps1 sync convention).

### Verified locally
| Summary.txt | Before | After |
|-------------|--------|-------|
| valid module rows | pass | **pass** |
| drifted (0 module rows) | **silent pass** ❌ | **fail** ✅ |

`build-pr.ps1` parses clean (`[Parser]::ParseFile` → PARSE OK).

## Why canonical

Surfaced by Copilot on **ETL-FixedWidth** v0.2.2 (#134); both files are identical fleet-wide. Fixing here for sync.