### PR TITLE
ci(release): add concurrency group so duplicate releases don't race

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: read  # Default to read-only; individual jobs declare write where required
 
+concurrency:
+  # Serialize releases so a duplicate / re-published Release event can't run two
+  # publish pipelines against NuGet and gh-pages at once. Never cancel an
+  # in-flight release — a half-published package family is worse than a queued one.
+  group: release-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
+
 env:
   CODECOV_MINIMUM: 90
 


### PR DESCRIPTION
## Summary

`release.yaml` had a `permissions:` block but **no `concurrency:` group** — unlike `pr.yaml` / `codeql.yaml` / `benchmarks.yaml`. A duplicate or re-published `release: published` event could run **two publish pipelines** against NuGet and gh-pages at once.

Adds a release-scoped concurrency group with `cancel-in-progress: false` (never cancel an in-flight release — a half-published package family is worse than a queued one):

```yaml
concurrency:
  group: release-${{ github.event.release.tag_name || github.ref }}
  cancel-in-progress: false
```

Surfaced by the code-review pass on **ETL-FixedWidth**; `release.yaml` is canonical, so fixing here for fleet sync.

> The other workflow nit from that review — `actions/checkout` `@v6`/`@v7` drift — is **Dependabot-managed** (the github-actions ecosystem bumps it fleet-wide) and self-heals, so it's intentionally not hand-edited here.