### PR TITLE
docfx.yaml: feed back coverage-trend + SHA-pinning + checkout@v7 (downstream → canonical)

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             5.0.x
@@ -197,8 +197,30 @@ jobs:
           $reports = ($coverageFiles | ForEach-Object { $_.FullName }) -join ';'
           $outDir = "docfx_project/_site/coverage"
           New-Item -ItemType Directory -Force -Path $outDir | Out-Null
-          reportgenerator "-reports:$reports" "-targetdir:$outDir" "-reporttypes:Html;TextSummary"
-          Write-Host "Coverage report written to $outDir"
+
+          # Coverage TREND (T1, #65): ReportGenerator renders a historical line
+          # chart when given a -historydir containing prior snapshots. We persist
+          # that history under _site/coverage/history so it deploys to gh-pages,
+          # and restore the previously-published snapshots from gh-pages before
+          # generating, so the trend accumulates across releases instead of
+          # resetting each deploy. Best-effort: any failure here just yields a
+          # point-in-time report (the step is continue-on-error regardless).
+          $historyDir = "$outDir/history"
+          New-Item -ItemType Directory -Force -Path $historyDir | Out-Null
+          try {
+            git fetch --no-tags --depth=1 origin gh-pages 2>&1 | Out-Host
+            $prior = @(git ls-tree -r --name-only FETCH_HEAD 2>$null | Where-Object { $_ -like 'coverage/history/*' })
+            foreach ($path in $prior) {
+              $leaf = Split-Path $path -Leaf
+              git show "FETCH_HEAD:$path" 2>$null | Set-Content -Path (Join-Path $historyDir $leaf) -Encoding utf8NoBOM
+            }
+            Write-Host "Restored $($prior.Count) prior coverage-history snapshot(s)."
+          } catch {
+            Write-Host "::notice::Could not restore prior coverage history ($($_.Exception.Message)) - starting fresh."
+          }
+
+          reportgenerator "-reports:$reports" "-targetdir:$outDir" "-reporttypes:Html;TextSummary" "-historydir:$historyDir"
+          Write-Host "Coverage report (with trend) written to $outDir"
 
       - name: Generate versions.json
         # Produces versions.json consumed by the DocFX version-switcher dropdown.


### PR DESCRIPTION
## Why

A fleet docfx drift-scan found downstream repos' `docfx.yaml` were **ahead** of repo-template canonical, not behind. The canonical here was the stale one. This promotes the most advanced downstream version (String-Extensions, 685 lines) so future syncs propagate the improvements *up* across the fleet instead of reverting them.

## What canonical was missing (now added)

| Improvement | Detail |
|---|---|
| **Coverage trend (T1, #65)** | ReportGenerator now renders a historical line chart: prior `coverage/history/*` snapshots are restored from `gh-pages` before generating, and re-published, so the trend accumulates across releases instead of resetting each deploy. Best-effort (`continue-on-error`). |
| **SHA-pinned actions (S2 hardening)** | `actions/checkout` and `actions/setup-dotnet` pinned to commit SHA with a `# v7` / `# v5` comment, preventing tag-hijack supply-chain attacks. |
| **`actions/checkout@v7`** | (via the SHA pin) — canonical was on `@v6`. |

All other content is identical to the current canonical (overlay-canonical-docs-assets, inline-HTML root redirect, etc.). The file is repo-agnostic (keys off `$env:GITHUB_REPOSITORY`), verified byte-identical to String-Extensions' working `docfx.yaml`.

## Fleet effect

After this merges, the ~9 repos currently at 663-line `docfx.yaml` (DbContextBuilder, ETL-*, IEquatable, etc.) will read as "behind canonical" — correctly — and pick up the coverage-trend + SHA-pinning on their next template sync. Convergence is upward.

## Not in scope

- `build-all-versions.yaml` — handled separately (the 2 split-landing time-bomb fixes: IAsyncEnumerable #269, D20-Dice #200).
- Per-repo fan-out of this docfx.yaml — follow-up via `bulk-repo-pr` once this canonical lands, if/when a broad docs-sync pass is wanted.

## Protected file → admin-bypass merge

Touches `.github/workflows/docfx.yaml`.