### PR TITLE
pr.yaml: quote $GITHUB_OUTPUT writes (SC2086)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -231,10 +231,10 @@ jobs:
         id: check-projects
         run: |
           if git ls-files '*.csproj' '*.vbproj' '*.fsproj' | grep -q .; then
-            echo "has-projects=true" >> $GITHUB_OUTPUT
+            echo "has-projects=true" >> "$GITHUB_OUTPUT"
             echo "✅ Found .NET project files - .NET build and test jobs will run"
           else
-            echo "has-projects=false" >> $GITHUB_OUTPUT
+            echo "has-projects=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
           fi
 
@@ -544,10 +544,10 @@ jobs:
         id: check-coverage
         run: |
           if find TestResults -type f -name "coverage.cobertura.xml" 2>/dev/null | grep -q .; then
-            echo "has-coverage=true" >> $GITHUB_OUTPUT
+            echo "has-coverage=true" >> "$GITHUB_OUTPUT"
             echo "✅ Coverage files found"
           else
-            echo "has-coverage=false" >> $GITHUB_OUTPUT
+            echo "has-coverage=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No coverage files found - skipping coverage report generation"
           fi
 


### PR DESCRIPTION
## Why

Surfaced by adding actionlint to a downstream repo's workflow-security check ([ETL-Csv#125](https://github.com/Chris-Wolfgang/ETL-Csv/pull/125), [#126](https://github.com/Chris-Wolfgang/ETL-Csv/pull/126)). actionlint's shellcheck integration flags four `SC2086` info-level findings on the bash heredocs in pr.yaml that write to `$GITHUB_OUTPUT` without quotes:

> Double quote to prevent globbing and word splitting

GitHub sets `GITHUB_OUTPUT` to a fixed path with no spaces or globs, so the prior form is safe in practice — but the quoted form is the universally-correct shape and matches what actionlint (and shellcheck v0.9+) keep expecting.

## Scope

Every fleet repo that syncs `pr.yaml` from this canonical inherits the bug. Spot-checked 5 representative repos (ETL-Json, ETL-FixedWidth, IEnumerable-Extensions, DateTime-Extensions, plus repo-template itself) — all 5 carry the same 4 unquoted writes.

After this lands, the fleet sync will propagate the fix downstream over time. A parallel manual fix sweep against each consumer repo is in flight in case the user wants the fleet patched without waiting for the next sync wave.

## Diff

```diff
-echo "has-projects=true"  >> $GITHUB_OUTPUT
-echo "has-projects=false" >> $GITHUB_OUTPUT
-echo "has-coverage=true"  >> $GITHUB_OUTPUT
-echo "has-coverage=false" >> $GITHUB_OUTPUT
+echo "has-projects=true"  >> "$GITHUB_OUTPUT"
+echo "has-projects=false" >> "$GITHUB_OUTPUT"
+echo "has-coverage=true"  >> "$GITHUB_OUTPUT"
+echo "has-coverage=false" >> "$GITHUB_OUTPUT"
```

## Not touched

PowerShell refs (`$env:GITHUB_OUTPUT`) at lines 850 + 853 are PowerShell syntax inside Stage 2 Windows jobs, not bash — shellcheck doesn't flag them and they don't need quoting.