### PR TITLE
ci: add ReSharper InspectCode as a parallel required check (#202)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -239,6 +239,81 @@ jobs:
           fi
 
   # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter). Tune the noise floor via .DotSettings at the repo root.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
+          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge — raise to `error`
+          # later when the noise floor is acceptable.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
   test-linux-core: 


### PR DESCRIPTION
## Summary

Adds a new `inspectcode` job to `pr.yaml` that runs JetBrains InspectCode on every PR, uploads SARIF to GitHub Code Scanning, and gates merge on `error`-severity findings. Canonical change for the cross-repo issue [Etl-DbClient#202](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/202).

## Why

The current static-analysis stack (Meziantou, SonarAnalyzer.CSharp, Roslynator, AsyncFixer, Microsoft.VisualStudio.Threading.Analyzers, BannedApiAnalyzers, .NET SDK analyzers, CodeQL, DevSkim) is comprehensive but exclusively Roslyn-based. **InspectCode runs a different ruleset** — data-flow analysis, dead-code detection, structural rules that Roslyn analyzers don't cover.

## Wiring

| | |
|---|---|
| Trigger | `needs: detect-projects` + same `if:` guard as Stage 1: skips on repo-template itself + no-projects PRs |
| Parallelism | **No `needs:` on a test stage** — runs concurrently with Stage 1 / 2 / 3, doesn't extend wall-clock (~3-5 min typical) |
| Tool | `JetBrains.ReSharper.GlobalTools` (free for OSS / CI use) |
| Build | Restore + `dotnet build -c Release --no-restore` (InspectCode needs compiled assemblies) |
| Inspect | `jb inspectcode <SLN> --output=inspect.sarif --format=sarif --severity=WARNING --no-build` |
| Solution discovery | Prefer `.slnx` (new format), fall back to `.sln`, fail loudly if neither |
| SARIF upload | `github/codeql-action/upload-sarif@v3` → findings in Security → Code scanning + inline PR annotations |
| Gate | `jq` extracts `level=="error"` findings; `>0` fails the job. `warning`-severity surfaces but doesn't gate (raise later once noise floor is tuned) |
| Timeout | 20 min (cold-runner first-install buffer) |
| Permissions | `contents: read` + `security-events: write` |

## Follow-up work tracked in #202

- **Canonical `.DotSettings`** at the repo root silencing rules already covered by Roslyn (style/formatting, async, nullability, IDE1006). Goal: 0 noise on a clean main so the first error after this lands is always actionable.
- Add **"ReSharper InspectCode"** to the required-status-checks ruleset on `main`.
- **Fan out** the workflow + `.DotSettings` to all 26 downstream Wolfgang.* repos via `bulk-repo-pr` once this is proven here.

## ⚠️ Protected-files note
Touches `.github/workflows/pr.yaml` and will trip the "Detect .NET Projects" guard. **Maintainer admin-bypass-and-merge** is the expected path (`feedback_protected_config_files_guard.md`). Be deliberate — bypass waives every ruleset gate including Copilot review per `feedback_admin_bypass_all_or_nothing.md`.

## Refs
- **#202** in Etl-DbClient (cross-repo issue text — partial; .DotSettings + ruleset + fleet fan-out pending follow-up PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)