### PR TITLE
ci: canonicalize solution-consistency guardrail in pr.yaml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -238,6 +238,74 @@ jobs:
             echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
           fi
 
+      - name: Verify src/ csprojs are in the solution
+        # Guards against a class of drift that shipped a broken release
+        # in Etl-DbClient v0.5.0: a new csproj was added under src/ (a
+        # source generator) but never added to the .slnx file. Per-project
+        # `dotnet test` still triggered its ProjectReference chain, so
+        # pr.yaml never noticed; but the release pipeline's solution-level
+        # `dotnet build` skipped it, and the runtime csproj's
+        # `PackSourceGenerator` MSBuild target failed to find the missing
+        # bin/Release/ output — blocking the release. This step catches
+        # the same drift at PR time.
+        #
+        # Detection: for every src/**/*.csproj, verify at least one solution
+        # file at the repo root references it by path (works for both .slnx
+        # `<Project Path="…"/>` entries and .sln GUID lines). If a solution
+        # file exists and a src csproj isn't listed, fail with the specific
+        # missing entry and a `dotnet sln add` suggestion. Repos without a
+        # solution file (or with everything already listed) pass
+        # unconditionally.
+        shell: bash
+        run: |
+          shopt -s nullglob
+          slns=( *.slnx *.sln )
+          if [ ${#slns[@]} -eq 0 ]; then
+            echo "ℹ️  No solution file at repo root - skipping solution-consistency check."
+            exit 0
+          fi
+          echo "Checking solution files: ${slns[*]}"
+
+          missing=()
+          # git ls-files always emits forward-slashed paths. .slnx entries
+          # use forward slashes, but classic .sln GUID lines often use
+          # backslashes (`src\Foo\Foo.csproj`). Check both encodings so a
+          # repo with a legacy .sln at the root isn't a false positive.
+          while IFS= read -r csproj; do
+            csproj_bs="${csproj//\//\\}"
+            found=0
+            for sln in "${slns[@]}"; do
+              if grep -qF "$csproj" "$sln" || grep -qF "$csproj_bs" "$sln"; then
+                found=1
+                break
+              fi
+            done
+            if [ "$found" -eq 0 ]; then
+              missing+=("$csproj")
+            fi
+          done < <(git ls-files 'src/**/*.csproj' 'src/*.csproj')
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo ""
+            echo "❌ SOLUTION CONSISTENCY FAILURE"
+            echo ""
+            echo "The following src/**/*.csproj files are NOT referenced by any solution file:"
+            for m in "${missing[@]}"; do
+              echo "  - $m"
+            done
+            echo ""
+            echo "This breaks solution-level \`dotnet build\` (which release.yaml relies on"
+            echo "for Pack & Validate), even though per-project \`dotnet test\` still works."
+            echo ""
+            echo "Fix: add the missing project(s) to the solution:"
+            for sln in "${slns[@]}"; do
+              echo "  dotnet sln $sln add ${missing[*]}"
+              break
+            done
+            exit 1
+          fi
+          echo "✅ All src csprojs are referenced by a solution file - solution-level builds will include them."
+
   # ============================================================================
   # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
   # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it


### PR DESCRIPTION
## Summary

Adds a **Verify src/ csprojs are in the solution** step to `detect-projects` in the canonical `pr.yaml`. Ready for fleet fan-out to all 26 downstream Wolfgang.* repos via the next template-sync round.

## Origin story

Etl-DbClient v0.5.0's release failed at **Pack & Validate** because a new csproj under `src/` (the source generator) was added in [#200](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/200) but never registered in the `.slnx` file.

- **Per-project `dotnet test`** invocations still triggered its ProjectReference chain, so **`pr.yaml` never noticed**.
- **release.yaml's solution-level `dotnet build --no-restore -c Release`** skipped it, and the runtime csproj's `PackSourceGenerator` MSBuild target failed to find the missing `bin/Release/` output — blocking the release.
- Recovered via [Etl-DbClient#222](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/222).

**This guard catches the same drift at PR time**, so no downstream repo can accidentally ship a solution-inconsistent PR that only breaks at release-tag time.

## Detection

For every `src/**/*.csproj`, verify at least one solution file at the repo root references it by path. Works for both:
- `.slnx`: `<Project Path="…" />` entries
- `.sln`: GUID lines

Repos without a solution file pass unconditionally (no false positives on repos that intentionally skip `.slnx`).

Failing output:

```
❌ SOLUTION CONSISTENCY FAILURE

The following src/**/*.csproj files are NOT referenced by any solution file:
  - src/Wolfgang.Etl.DbClient.SourceGenerator/…

This breaks solution-level `dotnet build` (which release.yaml relies on
for Pack & Validate), even though per-project `dotnet test` still works.

Fix: add the missing project(s) to the solution:
  dotnet sln <name>.slnx add <missing>
```

## Verified

Locally on Etl-DbClient via [PR #225](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/225) (parallel per-repo landing while this template-sync fans out):
- Current tree (source-gen in slnx): passes.
- Simulated pre-#222 state (source-gen removed): correctly reports the missing entry.

## Fleet fan-out

Next template-sync round picks this up across all downstream repos automatically.

## Refs
- **Etl-DbClient#222** — recovery fix
- **Etl-DbClient#225** — parallel per-repo landing (won't need re-work when template-sync fans out; already carries the identical step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)