### PR TITLE
Feed back CI-hardening workflows: Actions-audit, Semgrep, Scorecard (+ InspectCode shellcheck fix)

### DIFF
--- a/.github/workflows/actions-audit.yaml
+++ b/.github/workflows/actions-audit.yaml
@@ -1,0 +1,84 @@
+name: Actions Audit
+
+# GitHub Actions workflow security/quality audit (#185).
+#
+#  - actionlint: static checker for workflow YAML + embedded shell (via
+#    shellcheck). Gates the build on findings — workflows should be lint-clean.
+#  - zizmor: security auditor for Actions (injection, unpinned actions,
+#    over-broad permissions, ...). Reports to the Security tab (SARIF) rather
+#    than hard-gating, since it is opinionated; promote to a gate once the
+#    baseline is clean.
+#
+# Installed via `go install` / `pip install` (pinned) rather than third-party
+# wrapper actions, to keep the supply chain small.
+
+on:
+  # Runs on every PR (not path-filtered) so the actionlint job can be a required
+  # status check — a path-filtered required check would hang PRs that don't touch
+  # .github/workflows/**. actionlint/zizmor are cheap (~20s) and idempotent.
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actions-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: 'stable'
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+      - name: Run actionlint
+        run: actionlint -color
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Install zizmor
+        run: pip install zizmor
+
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Report-only for now: don't fail the job on findings, upload them to
+        # Code Scanning instead. Remove `|| true` to turn this into a gate.
+        run: zizmor --format sarif .github/workflows/ > zizmor.sarif || true
+
+      - name: Upload zizmor SARIF
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          sarif_file: zizmor.sarif

--- a/.github/workflows/actions-audit.yaml
+++ b/.github/workflows/actions-audit.yaml
@@ -35,12 +35,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 'stable'
 
@@ -59,12 +59,12 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
 
@@ -79,6 +79,6 @@ jobs:
         run: zizmor --format sarif .github/workflows/ > zizmor.sarif || true
 
       - name: Upload zizmor SARIF
-        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           sarif_file: zizmor.sarif

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -349,14 +349,15 @@ jobs:
         run: |
           # Find a solution to inspect. Prefer .slnx (new format) then .sln.
           # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
-          SLN=$(ls *.slnx 2>/dev/null | head -n1)
-          if [ -z "$SLN" ]; then
-            SLN=$(ls *.sln 2>/dev/null | head -n1)
-          fi
-          if [ -z "$SLN" ]; then
+          # Use bash globbing (nullglob) rather than `ls`: shellcheck-clean (no SC2012/SC2035)
+          # and a no-match pattern yields an empty array instead of aborting under set -e.
+          shopt -s nullglob
+          candidates=(*.slnx *.sln)
+          if [ ${#candidates[@]} -eq 0 ]; then
             echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
             exit 1
           fi
+          SLN="${candidates[0]}"
           echo "Inspecting: $SLN"
           jb inspectcode "$SLN" \
             --output=inspect.sarif \

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,50 @@
+name: OSSF Scorecard
+
+# Automated security-posture scoring via the OpenSSF Scorecard (#184).
+#
+# Scorecard evaluates the repo against supply-chain / security best practices
+# (branch protection, pinned dependencies, token permissions, dangerous
+# workflow patterns, ...) and uploads findings to Code Scanning. Runs on a
+# weekly schedule and on branch-protection changes; not per-PR (it scores the
+# repository, not a diff).
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '31 6 * * 1'   # Mondays at 06:31 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write   # upload the SARIF results
+      id-token: write          # publish results to the OpenSSF API
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -45,6 +45,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,61 @@
+name: SAST (Semgrep)
+
+# Security-grade static analysis beyond CodeQL (#164).
+#
+# Semgrep runs a different engine and ruleset from CodeQL (pattern/dataflow
+# rules for C#, a general security-audit pack, and a secrets pack), so it
+# surfaces issues CodeQL's queries don't. Findings upload to Code Scanning
+# (Security tab) as an additional signal; report-only for now (`|| true`) so a
+# noisy new ruleset can't block merges — promote to a gate once the baseline is
+# clean.
+#
+# Uses the public Semgrep registry packs, which need no account/login.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/csharp \
+            --config p/security-audit \
+            --config p/secrets \
+            --sarif --output semgrep.sarif \
+            --error || true
+
+      - name: Upload Semgrep SARIF
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -34,12 +34,12 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
 
@@ -56,6 +56,6 @@ jobs:
             --error || true
 
       - name: Upload Semgrep SARIF
-        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
Feeds the fleet-canonical CI-hardening workflows validated in **D20-Dice v0.7.1** back to the template.

## Added (repo-agnostic — no project-specific paths, drop in unchanged)
- **`actions-audit.yaml`** — actionlint (gate) + zizmor (report) over `.github/workflows/`. Runs on every PR so actionlint can be a required check.
- **`semgrep.yaml`** — SAST beyond CodeQL (public `p/csharp` + `security-audit` + `secrets` packs). Report-only.
- **`scorecard.yaml`** — OSSF Scorecard (SHA-pinned), weekly + on branch-protection changes.

## Fixed
- **`pr.yaml`** InspectCode solution-detection — the `ls *.slnx` / `ls *.sln` lines abort under the step's `set -e -o pipefail` when only one of `.slnx`/`.sln` exists, and trip shellcheck **SC2012/SC2035**. Replaced with bash `nullglob` array expansion. (This bug is live in every repo synced from the template.)

## Deliberately not in this PR (need genericization → follow-ups)
- `license-audit` (+config), `sbom`, `reproducible-build` — hardcode `src/Wolfgang.D20.Dice/…`; need glob project discovery (`git ls-files 'src/**/*.csproj'`) + a **no-projects skip guard** so the template's own CI doesn't fail.
- `perf-regression` — depends on a benchmark project + the gh-pages baseline.
- `aot-smoke` — needs a dedicated AOT smoke consumer project (repo-specific).

## Note
Protected workflow files → this PR trips the template's own `Detect .NET Projects` guard and needs an **admin-bypass** merge. Additive only (surgical `pr.yaml` edit, no full-file overwrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)