### PR TITLE
Feed back license-audit + SBOM workflows (genericized)

### DIFF
--- a/.github/license-audit/allowed-licenses.json
+++ b/.github/license-audit/allowed-licenses.json
@@ -1,0 +1,11 @@
+[
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MS-PL",
+  "0BSD",
+  "ISC",
+  "BSL-1.0",
+  "MPL-2.0"
+]

--- a/.github/license-audit/ignored-packages.json
+++ b/.github/license-audit/ignored-packages.json
@@ -1,0 +1,3 @@
+[
+  "SonarAnalyzer.CSharp"
+]

--- a/.github/license-audit/url-license-mappings.json
+++ b/.github/license-audit/url-license-mappings.json
@@ -1,0 +1,4 @@
+{
+  "http://go.microsoft.com/fwlink/?LinkId=329770": "MIT",
+  "https://github.com/dotnet/standard/blob/master/LICENSE.TXT": "MIT"
+}

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -1,0 +1,74 @@
+name: License Audit
+
+# License audit of transitive dependencies. Validates every src/ project's full
+# (direct + transitive) dependency closure against an allow-list of OSI-permissive
+# licenses using the `nuget-license` tool, and FAILS if any dependency's license is
+# not allowed (e.g. a copyleft or non-OSI license slipping in via a bump).
+#
+# Config lives in .github/license-audit/:
+#  - allowed-licenses.json     — the OSI-permissive licenses we accept.
+#  - url-license-mappings.json — maps a couple of Microsoft packages that expose a
+#    license URL (not an SPDX expression) to their actual license (MIT).
+#  - ignored-packages.json     — SonarAnalyzer.CSharp: a build-time analyzer
+#    (PrivateAssets=all, not shipped) under the non-OSI SONAR Source-Available
+#    License, so it imposes no obligation on consumers of the package.
+#
+# Skips automatically when the repo has no src/ project (e.g. the template repo).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: license-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  license-audit:
+    name: License audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect src projects
+        id: detect
+        run: |
+          if git ls-files 'src/**/*.csproj' 'src/*.csproj' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No src/**/*.csproj found — skipping license audit."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install nuget-license
+        if: steps.detect.outputs.found == 'true'
+        run: dotnet tool install --global nuget-license
+
+      # Gate: fail if any src project's dependency license is not on the allow-list.
+      - name: Audit licenses (gate on allow-list)
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          while IFS= read -r proj; do
+            echo "== $proj =="
+            dotnet restore "$proj"
+            nuget-license -i "$proj" -t \
+              -a .github/license-audit/allowed-licenses.json \
+              -ignore .github/license-audit/ignored-packages.json \
+              -mapping .github/license-audit/url-license-mappings.json \
+              -o Table
+          done < <(git ls-files 'src/**/*.csproj' 'src/*.csproj')

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,0 +1,74 @@
+name: SBOM
+
+# Supply-chain hardening — Software Bill of Materials. Generates a CycloneDX SBOM
+# for each src/ project's dependency graph and uploads them as an artifact, so every
+# build has a machine-readable inventory of what it is composed of.
+#
+# Scoped to the SBOM. The other supply-chain parts are deliberately out of this
+# workflow: SLSA provenance attestation belongs on the release artifact (attest the
+# packed .nupkg in release.yaml via actions/attest-build-provenance), and package
+# signing needs a signing certificate/key.
+#
+# Skips automatically when the repo has no src/ project (e.g. the template repo).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect src projects
+        id: detect
+        run: |
+          if git ls-files 'src/**/*.csproj' 'src/*.csproj' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No src/**/*.csproj found — skipping SBOM."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install CycloneDX
+        if: steps.detect.outputs.found == 'true'
+        run: dotnet tool install --global CycloneDX
+
+      - name: Generate CycloneDX SBOMs (JSON)
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          mkdir -p sbom
+          while IFS= read -r proj; do
+            name=$(basename "$proj" .csproj)
+            echo "== $proj =="
+            dotnet restore "$proj"
+            dotnet CycloneDX "$proj" --output "sbom/$name" --json
+          done < <(git ls-files 'src/**/*.csproj' 'src/*.csproj')
+
+      - name: Upload SBOMs
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom
+          path: sbom/


### PR DESCRIPTION
Follow-up to #434. Feeds the **license-audit** and **SBOM** workflows from D20-Dice v0.7.1 back to the template, **genericized** so they work for any repo (including multi-package) and skip cleanly where there's no `src/`.

## Genericization
- **Project discovery via glob** — `git ls-files 'src/**/*.csproj'` (looped), not a hardcoded `src/Wolfgang.D20.Dice/…` path, so multi-package repos audit **every** src project.
- **No-projects skip guard** — a `detect` step sets `found=false` and every working step is `if:`-guarded on it, so the job passes (skips) when there's no `src/` project — including **the template repo itself**, whose CI must stay green.

## Added
- **`license-audit.yaml`** — allow-list **gate** (fails on any non-permitted license) via `nuget-license`, with `.github/license-audit/` config (OSI-permissive allow-list, a build-only `SonarAnalyzer.CSharp` ignore, and Microsoft license-URL→MIT mappings). All fleet-generic.
- **`sbom.yaml`** — CycloneDX SBOM per src project, uploaded as an artifact.

## Verified
Detect glob finds `src` on a real repo (D20-Dice) and is empty → job skips on the template. Actions SHA-pinned; YAML validated.

## Note
Protected workflow files → **admin-bypass** merge, same as #434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)