### PR TITLE
ci: fix shellcheck SC2012/SC2035 in InspectCode solution lookup

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -349,9 +349,9 @@ jobs:
         run: |
           # Find a solution to inspect. Prefer .slnx (new format) then .sln.
           # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
-          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          SLN=$(find . -maxdepth 1 -name '*.slnx' | head -n1)
           if [ -z "$SLN" ]; then
-            SLN=$(ls *.sln 2>/dev/null | head -n1)
+            SLN=$(find . -maxdepth 1 -name '*.sln' | head -n1)
           fi
           if [ -z "$SLN" ]; then
             echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."


### PR DESCRIPTION
Canonical fix — propagates the `pr.yaml` shellcheck fix from ETL-FixedWidth back to the template.

The InspectCode step located the solution with `ls *.slnx` / `ls *.sln`, which shellcheck flags:
- **SC2012** — use `find` instead of `ls` to handle non-alphanumeric filenames
- **SC2035** — a bare glob can be interpreted as options and mishandles names with spaces/dashes (e.g. `ETL Fixed Width.slnx`)

Both replaced with `find . -maxdepth 1 -name '*.slnx' | head -n1`.

### Why it only showed up now
A new **actionlint + zizmor workflow-security** gate (thorough-review #163, being rolled out downstream) runs actionlint *with shellcheck on the runner*. A bare local actionlint has no shellcheck, so this pre-existing finding was invisible locally and only failed in CI. Fixing at the template means every downstream that syncs `pr.yaml` inherits it.

### Validation
- `actionlint` + `shellcheck 0.11.0` on `pr.yaml` → **exit 0, clean**.

⚠️ Touches `pr.yaml` (protected) → the protected-file guard will require an **admin-bypass merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)