### PR TITLE
fix(docs): version-picker shows 'latest' only on /versions/latest/

### DIFF
--- a/docfx_project/public/version-picker.js
+++ b/docfx_project/public/version-picker.js
@@ -49,8 +49,14 @@
     }
 
     function renderPicker(versions) {
-        // Detect the currently-viewed version from the URL.
-        var currentVersion = 'latest';
+        // Detect the currently-viewed version from the URL. Only a
+        // /versions/<v>/ path names a concrete version; the literal
+        // /versions/latest/ alias yields 'latest'. Anywhere else (site
+        // root, unversioned pages) currentVersion stays null so the
+        // 'latest' alias is NOT surfaced and the browser auto-selects the
+        // highest v* entry — matching the intent that 'latest' appears in
+        // the picker only on /versions/latest/.
+        var currentVersion = null;
         var m = window.location.pathname.match(/\/versions\/([^\/]+)(?:\/|$)/);
         if (m) {
             currentVersion = m[1];
@@ -86,12 +92,16 @@
         var optionCount = 0;
         versions.forEach(function (v) {
             if (!v || !v.version || !v.url) return;
-            // Skip the "latest" alias — the highest-numbered v* entry
-            // already represents the latest release; surfacing both is
-            // redundant in the picker. versions.json keeps the "latest"
-            // entry so other consumers (links, scripts) can still
+            // Skip the "latest" alias EXCEPT when the reader is actually
+            // on /versions/latest/. On every other page the highest-
+            // numbered v* entry already represents the latest release and
+            // surfacing both is redundant; on /versions/latest/ we NEED
+            // 'latest' in the list because otherwise the picker would show
+            // no selected option and the reader would have no way to know
+            // which version they are viewing. versions.json keeps the
+            // "latest" entry so other consumers (links, scripts) can still
             // resolve it.
-            if (v.version === 'latest') return;
+            if (v.version === 'latest' && currentVersion !== 'latest') return;
             var opt = document.createElement('option');
             opt.value = v.url;
             opt.textContent = v.version;

--- a/docfx_project/public/version-picker.js
+++ b/docfx_project/public/version-picker.js
@@ -96,10 +96,12 @@
             // on /versions/latest/. On every other page the highest-
             // numbered v* entry already represents the latest release and
             // surfacing both is redundant; on /versions/latest/ we NEED
-            // 'latest' in the list because otherwise the picker would show
-            // no selected option and the reader would have no way to know
-            // which version they are viewing. versions.json keeps the
-            // "latest" entry so other consumers (links, scripts) can still
+            // 'latest' in the list because without it the browser auto-
+            // selects the first concrete version (whichever v* is top of
+            // the list), and choosing that same value doesn't fire
+            // `change`, so the reader can't navigate away to the
+            // concrete-version URL. versions.json keeps the "latest"
+            // entry so other consumers (links, scripts) can still
             // resolve it.
             if (v.version === 'latest' && currentVersion !== 'latest') return;
             var opt = document.createElement('option');


### PR DESCRIPTION
Feeds back the fix from Chris-Wolfgang/ETL-Abstractions#268 to the canonical template.

## Problem
`renderPicker` defaulted `currentVersion` to `'latest'`. Because the `latest` alias is skipped *unless* `currentVersion === 'latest'`, that default surfaced **and selected** the `latest` option on the site root and every unversioned page — not just on `/versions/latest/` as intended.

## Fix
Default `currentVersion` to `null`. Only a `/versions/<v>/` path (including the literal `/versions/latest/`) now names a version:

- **`/versions/1.2.3/`** → `1.2.3` selected, `latest` hidden (unchanged).
- **`/versions/latest/`** → `latest` surfaced and selected (so the reader can see which version they're viewing).
- **site root / unversioned pages** → `latest` hidden; the browser auto-selects the highest `v*` entry.

Note: the canonical file was an older baseline than the downstream copies, so this also brings in the `/versions/latest/` awareness those copies already had.

Docs-only JS; no behavior change to the build.
