### PR TITLE
ci(pr): make InspectCode robust — full SDK set + nullglob solution discovery

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -360,16 +360,23 @@ jobs:
 
       - name: Run InspectCode
         run: |
-          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
-          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
-          SLN=$(ls *.slnx 2>/dev/null | head -n1)
-          if [ -z "$SLN" ]; then
-            SLN=$(ls *.sln 2>/dev/null | head -n1)
-          fi
-          if [ -z "$SLN" ]; then
+          # Global dotnet tools install under ~/.dotnet/tools; make sure `jb`
+          # resolves regardless of whether that dir is already on PATH.
+          export PATH="$HOME/.dotnet/tools:$PATH"
+          # Find a solution to inspect, preferring .slnx (new format) over .sln.
+          # Use nullglob + array expansion instead of parsing `ls`: a glob with
+          # no match expands to nothing rather than failing, so this is correct
+          # under the step's `set -e -o pipefail` shell by construction — no `ls`
+          # exit-2 to swallow, and no blanket `|| true` that would also hide a
+          # genuine failure. Listing *.slnx before *.sln keeps any .slnx ahead
+          # of a .sln in the array, so ${solutions[0]} is a .slnx when one exists.
+          shopt -s nullglob
+          solutions=(*.slnx *.sln)
+          if [ ${#solutions[@]} -eq 0 ]; then
             echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
             exit 1
           fi
+          SLN="${solutions[0]}"
           echo "Inspecting: $SLN"
           jb inspectcode "$SLN" \
             --output=inspect.sarif \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -335,7 +335,20 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          # Install every SDK the test stages install. Solutions that
+          # multi-target out-of-support TFMs (netcoreapp3.1 / net5.0 /
+          # net6.0 / net7.0) are not guaranteed to restore their targeting
+          # packs under a lone 10.0.x SDK, so the solution build below can
+          # fail even when the test stages (which install 3.1.x-10.0.x)
+          # pass. Mirror those stages so InspectCode builds the same TFM set.
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Restore + Build (Release)
         run: |


### PR DESCRIPTION
Feeds back two InspectCode robustness fixes from Chris-Wolfgang/ETL-Abstractions to the canonical template. Both were latent in the canonical `inspectcode` job and never actually surfaced there because the job is guarded off on repo-template itself (`if: github.repository != 'Chris-Wolfgang/repo-template'`).

## 1. Install the full SDK set (from ETL-Abstractions#267)
The job installed only `10.0.x`, but `Restore + Build (Release)` builds the whole solution. Downstream solutions that multi-target out-of-support TFMs (`netcoreapp3.1`, `net5.0`, `net6.0`, `net7.0`) aren't guaranteed to restore their targeting packs under a lone `10.0.x` SDK, so the build can fail even when the test stages (which install `3.1.x`–`10.0.x`) pass. Install the same SDK set.

## 2. Robust solution discovery (from ETL-Abstractions#274)
The "Run InspectCode" step parsed `ls *.slnx` to select a solution. Under GitHub's `shell: bash` (`-e -o pipefail`), a no-match `ls` exits 2, `pipefail` propagates it, and `errexit` aborts the step **before the `.sln` fallback runs** — so any repo that has only a `.sln` fails InspectCode. Replaced with `nullglob` + array expansion (a non-matching glob expands to nothing, correct under errexit by construction; `.slnx` stays preferred). Also puts `~/.dotnet/tools` on `PATH` so `jb` resolves.

Verified in a local `bash -e -o pipefail` harness: only-`.sln` ✓, only-`.slnx` ✓, both (`.slnx` wins) ✓, neither (exit 1) ✓.

## Out of scope (tracked separately)
The canonical InspectCode job runs on `ubuntu-latest` and builds the whole solution, which will also fail for downstream repos that have `net4x` projects (no Framework reference assemblies on Linux). ETL-Abstractions worked around this by moving to `windows-latest`. That broader decision is #440.

## Merge note
Touches `.github/workflows/pr.yaml` (protected), so the protected-file guard will fail by design — needs an admin-bypass merge.
