### PR TITLE
ci(release): NuGet trusted publishing (OIDC) instead of stored API key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -672,6 +672,9 @@ jobs:
     needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
+    permissions:
+      id-token: write  # OIDC token for NuGet trusted publishing (no stored API key)
+      contents: read
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -691,22 +694,16 @@ jobs:
           name: nuget-packages
           path: ./packages
 
-      - name: Validate NuGet API key
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
-            Write-Error "❌ NUGET_API_KEY secret not configured!"
-            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
-            exit 1
-          }
-          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+      - name: NuGet login (OIDC trusted publishing)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: Chris-Wolfgang
 
       - name: Publish to NuGet
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
           


### PR DESCRIPTION
Feeds back the OIDC trusted-publishing change from Chris-Wolfgang/ETL-Abstractions#287 to the canonical template.

**publish-nuget job:** adds `permissions: id-token: write`, replaces the `Validate NuGet API key` + key-based push with `NuGet/login@v1` (`user: Chris-Wolfgang`) → short-lived key → existing `dotnet nuget push`. No stored, expiring secret in the publish path.

**Why:** an expired `NUGET_API_KEY` 403'd ETL-Abstractions' v0.16.0 publish. Trusted publishing removes that failure mode fleet-wide.

**Per-repo follow-up (not automatable here):** each repo that adopts this still needs its own NuGet.org trusted-publisher policy (Repository owner `Chris-Wolfgang`, its own repo name, Workflow `release.yaml`, Environment blank). `NUGET_API_KEY` secrets can be deleted once policies exist.

**Merge note:** protected `release.yaml` → `Detect .NET Projects` fails by design → admin-bypass.