### PR TITLE
build: gitleaks OS+arch runtime selection in build-pr.ps1 (macOS + Linux arm64)

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -306,7 +306,13 @@ if (-not $SkipSecurity) {
             $env:PATH = "$dest;$env:PATH"
         }
         else {
-            $archive = "gitleaks_${version}_linux_x64.tar.gz"
+            # gitleaks ships separate per-OS, per-arch builds. Select BOTH from
+            # the running runtime so this works on x64 and arm64 for macOS AND
+            # Linux (Apple Silicon, AWS Graviton, ARM CI runners) — hard-coding
+            # linux_x64 fetches an incompatible binary on macOS and ARM64 Linux.
+            $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+            $os = if ($IsMacOS) { 'darwin' } else { 'linux' }
+            $archive = "gitleaks_${version}_${os}_${arch}.tar.gz"
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
             # Install to a user-writable location instead of /usr/local/bin
             # (which would require sudo for most local dev shells). $HOME/.local/bin


### PR DESCRIPTION
Feeds back the gitleaks arch fix from Chris-Wolfgang/ETL-Abstractions#288 (issue #270). The canonical `build-pr.ps1` hard-coded `linux_x64` on the non-Windows path (no macOS handling either), so it fetched an incompatible binary on macOS and ARM64 Linux.

Compute both dimensions from the runtime — `$os` from `$IsMacOS` (darwin/linux), `$arch` from `OSArchitecture` (arm64/x64) — covering `darwin_x64`/`darwin_arm64`/`linux_x64`/`linux_arm64`. Not a protected file → normal CI. Parses clean; all four asset names verified in the downstream PR.