### PR TITLE
docs(readme-template): canonical 7-badge set + Supported Frameworks section

### DIFF
--- a/README-TEMPLATE.md
+++ b/README-TEMPLATE.md
@@ -2,6 +2,10 @@
 
 {{PROJECT_DESCRIPTION}}
 
+[![NuGet](https://img.shields.io/nuget/v/{{PACKAGE_NAME}}.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/{{PACKAGE_NAME}}/)
+[![Downloads](https://img.shields.io/nuget/dt/{{PACKAGE_NAME}}.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/{{PACKAGE_NAME}}/)
+[![PR build](https://img.shields.io/github/actions/workflow/status/{{GITHUB_OWNER}}/{{REPO_NAME}}/pr.yaml?event=pull_request_target&label=PR%20build&logo=github)]({{GITHUB_REPO_URL}}/actions/workflows/pr.yaml)
+[![release](https://img.shields.io/github/actions/workflow/status/{{GITHUB_OWNER}}/{{REPO_NAME}}/release.yaml?event=release&label=release&logo=github)]({{GITHUB_REPO_URL}}/actions/workflows/release.yaml)
 [![License: {{LICENSE_TYPE}}](https://img.shields.io/badge/License-{{LICENSE_TYPE}}-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)]({{GITHUB_REPO_URL}})
@@ -48,13 +52,11 @@ This project is licensed under the **{{LICENSE_TYPE}} License**. See the [LICENS
 
 ---
 
-## 🎯 Target Frameworks
+## 🎯 Supported Frameworks
 
-| Framework | Versions |
-|-----------|----------|
-| .NET Framework | .NET 4.6.2, .NET 4.7.0, .NET 4.7.1, .NET 4.7.2, .NET 4.8, .NET 4.8.1 |
-| .NET Core | .NET Core 3.1 |
-| .NET | .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0, .NET 10.0 |
+{{TARGET_FRAMEWORKS}}
+
+See the [NuGet package page](https://www.nuget.org/packages/{{PACKAGE_NAME}}/) for the authoritative per-TFM compatibility matrix.
 
 ---
 

--- a/TEMPLATE-PLACEHOLDERS.md
+++ b/TEMPLATE-PLACEHOLDERS.md
@@ -28,6 +28,7 @@ These placeholders are **required** and must be replaced in every project:
 | `{{GITHUB_REPO_URL}}` | Full GitHub repository URL | `https://github.com/Chris-Wolfgang/MyProject` | Yes (from `git remote`) |
 | `{{REPO_NAME}}` | Repository name only | `MyProject` | Yes (extracted from URL) |
 | `{{GITHUB_USERNAME}}` | GitHub username with @ | `@Chris-Wolfgang` | Yes (from GitHub repo URL, or prompted if missing) |
+| `{{GITHUB_OWNER}}` | GitHub owner slug (no @, URL-safe) | `Chris-Wolfgang` | Yes (derived from `GITHUB_USERNAME`) |
 | `{{DOCS_URL}}` | Documentation URL | `https://chris-wolfgang.github.io/MyProject/` | Yes (generated from repo URL) |
 | `{{LICENSE_TYPE}}` | License identifier | `MIT`, `Apache-2.0`, or `MPL-2.0` | No |
 | `{{YEAR}}` | Copyright year | `2024` | Yes (current year) |
@@ -47,7 +48,7 @@ These placeholders represent sections that users should fill in later. They can 
 | `{{QUICK_START_EXAMPLE}}` | Code example showing basic usage | README.md |
 | `{{FEATURES_TABLE}}` | Markdown table listing features | README.md |
 | `{{FEATURE_EXAMPLES}}` | Code examples demonstrating features | README.md |
-| `{{TARGET_FRAMEWORKS}}` | List of supported .NET frameworks | README.md |
+| `{{TARGET_FRAMEWORKS}}` | Bullet list of supported .NET frameworks for the "Supported Frameworks" section (copy from your source csproj's `<TargetFrameworks>`) | README.md |
 | `{{ACKNOWLEDGMENTS}}` | Credits for libraries/tools used | README.md |
 
 **Note:** The automated setup scripts do NOT replace these - users fill them in as they develop their project.
@@ -130,7 +131,7 @@ The setup script validates that these placeholders are properly replaced (along 
 ```powershell
 $corePlaceholders = @(
     'PROJECT_NAME', 'PROJECT_DESCRIPTION', 'PACKAGE_NAME',
-    'GITHUB_REPO_URL', 'REPO_NAME', 'GITHUB_USERNAME',
+    'GITHUB_REPO_URL', 'REPO_NAME', 'GITHUB_USERNAME', 'GITHUB_OWNER',
     'DOCS_URL', 'LICENSE_TYPE',
     'NUGET_STATUS', 'TEMPLATE_REPO_OWNER', 'TEMPLATE_REPO_NAME'
 )
@@ -152,20 +153,24 @@ $corePlaceholders = @(
 |---------|-------------|---------|
 | 1 | `{{PROJECT_NAME}}` | Main heading |
 | 3 | `{{PROJECT_DESCRIPTION}}` | Project description |
-| 5 | `{{LICENSE_TYPE}}` | License badge |
-| 7 | `{{GITHUB_REPO_URL}}` | GitHub badge link |
-| 13 | `{{PACKAGE_NAME}}` | Installation command |
-| 16 | `{{NUGET_STATUS}}` | NuGet availability |
-| 21 | `{{LICENSE_TYPE}}` | License section |
-| 27 | `{{GITHUB_REPO_URL}}` | Documentation link (2 occurrences) |
-| 28 | `{{DOCS_URL}}` | API documentation URL |
-| 35 | `{{QUICK_START_EXAMPLE}}` | Quick start code |
-| 41 | `{{FEATURES_TABLE}}` | Features table |
-| 44 | `{{FEATURE_EXAMPLES}}` | Feature examples |
-| 50 | `{{TARGET_FRAMEWORKS}}` | Framework list |
-| 119 | `{{GITHUB_REPO_URL}}` | Clone command |
-| 120 | `{{REPO_NAME}}` | Directory name |
-| 197 | `{{ACKNOWLEDGMENTS}}` | Acknowledgments section |
+| 5–6 | `{{PACKAGE_NAME}}` | NuGet version + downloads badges |
+| 7 | `{{GITHUB_OWNER}}`, `{{REPO_NAME}}`, `{{GITHUB_REPO_URL}}` | PR build badge |
+| 8 | `{{GITHUB_OWNER}}`, `{{REPO_NAME}}`, `{{GITHUB_REPO_URL}}` | Release build badge |
+| 9 | `{{LICENSE_TYPE}}` | License badge |
+| 11 | `{{GITHUB_REPO_URL}}` | GitHub badge link |
+| 18 | `{{PACKAGE_NAME}}` | Installation command |
+| 21 | `{{NUGET_STATUS}}` | NuGet availability |
+| 27 | `{{LICENSE_TYPE}}` | License section |
+| 33 | `{{GITHUB_REPO_URL}}` | Documentation link (2 occurrences) |
+| 34 | `{{DOCS_URL}}` | API documentation URL |
+| 42 | `{{QUICK_START_EXAMPLE}}` | Quick start code |
+| 48 | `{{FEATURES_TABLE}}` | Features table |
+| 51 | `{{FEATURE_EXAMPLES}}` | Feature examples |
+| 57 | `{{TARGET_FRAMEWORKS}}` | Supported Frameworks list |
+| 59 | `{{PACKAGE_NAME}}` | NuGet package matrix link |
+| 103 | `{{GITHUB_REPO_URL}}` | Clone command |
+| 104 | `{{REPO_NAME}}` | Directory name |
+| 182 | `{{ACKNOWLEDGMENTS}}` | Acknowledgments section |
 
 ### 2. CONTRIBUTING.md
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -484,6 +484,7 @@ function Start-Setup {
         'GITHUB_REPO_URL' = $githubRepoUrl
         'REPO_NAME' = $repoName
         'GITHUB_USERNAME' = $githubUsername
+        'GITHUB_OWNER' = $githubUsername.TrimStart('@')
         'DOCS_URL' = $docsUrl
         'LICENSE_TYPE' = $licenseType
         'YEAR' = $year
@@ -794,7 +795,7 @@ function Start-Setup {
     # Note: YEAR and COPYRIGHT_HOLDER are handled in LICENSE file generation, not in FILES_TO_UPDATE
     $corePlaceholders = @(
         'PROJECT_NAME', 'PROJECT_DESCRIPTION', 'PACKAGE_NAME',
-        'GITHUB_REPO_URL', 'REPO_NAME', 'GITHUB_USERNAME',
+        'GITHUB_REPO_URL', 'REPO_NAME', 'GITHUB_USERNAME', 'GITHUB_OWNER',
         'DOCS_URL', 'LICENSE_TYPE',
         'NUGET_STATUS', 'TEMPLATE_REPO_OWNER', 'TEMPLATE_REPO_NAME'
     )


### PR DESCRIPTION
Closes part of #448 (Gap 4: repo-template placeholder badges + fleet-wide `## Supported Frameworks` template).

## What changes

`README-TEMPLATE.md` — the file downstream repos inherit as their `README.md` after `setup.ps1` runs — now carries the fleet-canonical 7-badge set in the canonical order:

1. `nuget-version`
2. `nuget-downloads`
3. `wf:pr` (with `?event=pull_request_target` so shields.io filters to the workflow that actually runs)
4. `wf:release` (with `?event=release` same reason)
5. License
6. `.NET Multi-Targeted`
7. GitHub Repository

Previously only badges 5–7 were present, so every downstream repo scaffolded from this template started life missing the four publication badges. Gap 1 of the audit (all 9 ETL repos missing all 4) traces back to this template gap.

The hardcoded `## 🎯 Target Frameworks` table (which enumerated every possible TFM regardless of what the downstream repo actually targeted) is replaced with the existing `{{TARGET_FRAMEWORKS}}` placeholder, renamed to `## 🎯 Supported Frameworks`. Downstream repos fill it with a bullet list copied from their csproj's `<TargetFrameworks>`. A link to the NuGet package page is added as the authoritative per-TFM matrix.

## New placeholder: `{{GITHUB_OWNER}}`

The workflow-status badge URLs need the owner slug (e.g. `Chris-Wolfgang`), but `{{GITHUB_USERNAME}}` is defined to include the `@` prefix (`@Chris-Wolfgang`) which is not URL-safe. Rather than repurpose that placeholder (breaking callers who rely on the `@`), a new `{{GITHUB_OWNER}}` is derived from `$githubUsername.TrimStart('@')` in `setup.ps1`.

Wired through:
- `scripts/setup.ps1` — added to the replacements hashtable and to the `$corePlaceholders` validation list.
- `TEMPLATE-PLACEHOLDERS.md` — documented as a core auto-derived placeholder.

## Fleet followup

This PR only closes Gap 4 (the template itself). Downstream repos already scaffolded from the previous template still have the old badge set — those are Gap 1 (9 ETL repos), Gap 2 (System.Mail-Extensions), and Gap 3 (AuditTrail), tracked in #448. Fan-out PRs for those are next.

## Verification

- Template renders cleanly (no `{{...}}` leftovers on non-core placeholders): visual inspection.
- The per-line placeholder index in `TEMPLATE-PLACEHOLDERS.md` is updated to match the new file (badge block shifts + Supported Frameworks section shifts subsequent lines by +4).
