### PR TITLE
security(ci): close .DotSettings gap in pr.yaml protected-file guard

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -118,6 +118,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -198,14 +199,16 @@ jobs:
             fi
           done
           
-          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
+          # Check .globalconfig, .ruleset, .DotSettings, and workflow files using
+          # the same git diff approach.
           # --diff-filter=AMRCD: Added, Modified, Renamed, Copied, Deleted.
           # Including D so a PR that *deletes* a protected file (workflow,
-          # .globalconfig, .ruleset) also triggers the maintainer-review gate
-          # — a silent deletion is just as security-relevant as a silent edit.
+          # .globalconfig, .ruleset, .DotSettings) also triggers the
+          # maintainer-review gate — a silent deletion is just as
+          # security-relevant as a silent edit.
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset|DotSettings)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
@@ -416,6 +419,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -839,7 +843,7 @@ jobs:
           }
           
           # Handle glob patterns for .globalconfig, .ruleset, and workflow files
-          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
+          $globPatterns = @("*.globalconfig", "*.ruleset", "*.DotSettings", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -1136,6 +1140,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -1540,6 +1545,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )


### PR DESCRIPTION
## Summary

- The InspectCode job's own comment already flags `.DotSettings` as a protected-config vector:
  > a malicious PR could ship a permissive .editorconfig / BannedSymbols.txt / **.DotSettings** that would silence InspectCode findings on the PR's own code.
- But `*.DotSettings` was missing from every `config_files=(...)` array — so downstream repos that took this workflow via template-sync had a gap the code did not close. A PR could ship its own `.DotSettings` suppression file and InspectCode would honor it, since InspectCode's noise floor is tuned via `.DotSettings` at the repo root.
- Adds `*.DotSettings` to all four bash arrays plus the Windows-stage pwsh `\$globPatterns`, and extends the `Detect protected configuration file changes` regex so a PR that touches its own `.DotSettings` gets the same maintainer-review gate as `.editorconfig` / `.globalconfig` / `.ruleset` / workflow files already do.
- Matches the fix landing in `Chris-Wolfgang/ETL-Abstractions#379` — this PR feeds the same change back into the canonical template so downstream repos pick it up on the next template-drift sweep.

## Notes for merge

- This PR modifies a workflow file, so `Detect .NET Projects` will fail with the "protected config file changed" gate. **Admin bypass required** — this PR *is* the one-file protected-file-PR-split.

## Test plan

- [ ] Admin-bypass merge to main
- [ ] Template-drift-scan surfaces `pr.yaml` as up-to-date for repos that pull it via template-sync
- [ ] On the next PR in a downstream repo that touches `.DotSettings`, confirm `Detect .NET Projects` flags it

🤖 Generated with [Claude Code](https://claude.com/claude-code)