### PR TITLE
fix(ci): gate test assemblies at 100%, src at 90%

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,7 +21,15 @@ permissions:
   contents: read
 
 env:
+  # Minimum line coverage for PRODUCTION assemblies (anything under src/).
   CODECOV_MINIMUM: 90
+  # Minimum line coverage for TEST assemblies (anything under tests/).
+  # Test code that never executes has no purpose — an uncovered helper, fake, or
+  # branch in a test project is dead code and should be exercised or deleted.
+  # This is LINE coverage; branch coverage legitimately can't reach 100%
+  # (compiler-generated async state machines), and the gate reads only the
+  # line-coverage column that ReportGenerator puts at end-of-row.
+  CODECOV_TEST_MINIMUM: 100
   
 on:
   pull_request_target:  # Runs from the main branch, not from PR branch
@@ -720,9 +728,39 @@ jobs:
           
           failed_projects=""
           threshold=${CODECOV_MINIMUM:-90}
+          test_threshold=${CODECOV_TEST_MINIMUM:-100}
           matched_count=0
 
-          while read -r line; do
+          # Build the set of assembly names produced by projects under tests/.
+          #
+          # DO NOT identify test assemblies by name. Shipped PRODUCT packages
+          # legitimately contain "Test" — e.g. Wolfgang.Etl.TestKit and
+          # Wolfgang.AuditTrail.TestKit.Xunit — and they live in src/. Matching
+          # on the name would hold product code to the test threshold. The
+          # project's LOCATION is the only reliable discriminator.
+          #
+          # Delimited with '|' on both sides so membership tests can't match a
+          # prefix (|Foo| must not match |FooBar|).
+          test_assemblies="|"
+          if [ -d ./tests ]; then
+            while IFS= read -r -d '' proj; do
+              asm=$(grep -oE '<AssemblyName>[^<]+' "$proj" 2>/dev/null | head -1 | cut -d'>' -f2)
+              if [ -z "$asm" ]; then
+                asm=$(basename "$proj"); asm="${asm%.*}"
+              fi
+              test_assemblies="${test_assemblies}${asm}|"
+            done < <(find ./tests -type f \( -name '*.csproj' -o -name '*.vbproj' -o -name '*.fsproj' \) -print0)
+          fi
+          echo "Test assemblies (gated at ${test_threshold}%): ${test_assemblies}"
+          echo ""
+
+          # IFS= is REQUIRED. ReportGenerator indents per-class rows two spaces
+          # beneath their parent assembly row, and the filter below anchors on
+          # `^[^ ]` to skip them. A bare `read -r line` strips leading IFS
+          # whitespace, so the indentation is gone before grep sees it and every
+          # class row matches — which gated individual test classes as if they
+          # were projects.
+          while IFS= read -r line; do
             # Match lines with module names and percentages. The percent
             # capture is the LAST %-suffixed number on the line, matching
             # Stage 2's behavior — ReportGenerator Summary.txt rows often
@@ -736,13 +774,32 @@ jobs:
               percent=$(echo "$line" | awk '{print $NF}' | tr -d '%' | awk '{print int($1)}')
               matched_count=$((matched_count + 1))
 
-              echo "Checking module: '$module' - Coverage: ${percent}%"
+              # Gating the test ASSEMBLY row at 100% is equivalent to gating
+              # every one of its classes: an assembly only reaches 100% line
+              # coverage when every class in it is at 100%.
+              case "$test_assemblies" in
+                *"|${module}|"*) applies=$test_threshold; kind="test" ;;
+                *)               applies=$threshold;      kind="src"  ;;
+              esac
 
-              if [ "$percent" -lt "$threshold" ]; then
-                echo "  ❌ FAIL: Below ${threshold}% threshold"
-                failed_projects="$failed_projects $module (${percent}%)"
+              echo "Checking ${kind} module: '$module' - Coverage: ${percent}%"
+
+              if [ "$percent" -lt "$applies" ]; then
+                echo "  ❌ FAIL: Below ${applies}% threshold"
+                failed_projects="$failed_projects $module (${percent}%, needs ${applies}%)"
+                # For a test assembly, name the classes that are short so the
+                # fix is obvious without downloading the coverage artifact.
+                if [ "$kind" = "test" ]; then
+                  echo "  Classes below ${applies}%:"
+                  awk -v asm="$module" '
+                    /^[^ ]/ { in_asm = ($1 == asm) }
+                    in_asm && /^  / && /[0-9]+(\.[0-9]+)?%$/ {
+                      p = $NF; gsub("%","",p);
+                      if (p + 0 < 100) printf "    %s  %s\n", $NF, $1
+                    }' CoverageReport/Summary.txt
+                fi
               else
-                echo "  ✅ PASS: Meets ${threshold}% threshold"
+                echo "  ✅ PASS: Meets ${applies}% threshold"
               fi
             fi
           done < CoverageReport/Summary.txt
@@ -760,7 +817,11 @@ jobs:
             echo "=========================================="
             echo "❌ COVERAGE GATE FAILED"
             echo "=========================================="
-            echo "Projects below ${threshold}% coverage: $failed_projects"
+            echo "Modules below their threshold: $failed_projects"
+            echo ""
+            echo "src assemblies must reach ${threshold}%; test assemblies must reach ${test_threshold}%."
+            echo "For test assemblies: write a test first; if that isn't possible, refactor"
+            echo "to make the code testable; use [ExcludeFromCodeCoverage] only as a last resort."
             echo ""
             echo "Stage 1 failed. Windows, macOS, and .NET Framework tests will NOT run."
             exit 1
@@ -769,7 +830,7 @@ jobs:
             echo "=========================================="
             echo "✅ COVERAGE GATE PASSED"
             echo "=========================================="
-            echo "All projects meet ${threshold}% coverage threshold."
+            echo "src assemblies meet ${threshold}%; test assemblies meet ${test_threshold}%."
             echo "Proceeding to Stage 2 (Windows and macOS tests)."
           fi
 
@@ -1024,9 +1085,26 @@ jobs:
           Get-Content "CoverageReport/Summary.txt"
           Write-Host ""
 
-          $threshold = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
+          $threshold     = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
+          $testThreshold = if ($env:CODECOV_TEST_MINIMUM) { [int]$env:CODECOV_TEST_MINIMUM } else { 100 }
           $failedProjects = @()
           $matchedCount   = 0
+
+          # Set of assembly names produced by projects under tests/ — see the
+          # matching Stage 1 block. Identify test assemblies by LOCATION, never
+          # by name: shipped product packages such as Wolfgang.Etl.TestKit and
+          # Wolfgang.AuditTrail.TestKit.Xunit contain "Test" and live in src/,
+          # and matching on the name would hold product code to the test
+          # threshold.
+          $testAssemblies = @()
+          if (Test-Path "tests") {
+            Get-ChildItem -Path "tests" -Recurse -File -Include *.csproj,*.vbproj,*.fsproj | ForEach-Object {
+              $m = [regex]::Match((Get-Content $_.FullName -Raw), '<AssemblyName>([^<]+)</AssemblyName>')
+              $testAssemblies += $(if ($m.Success) { $m.Groups[1].Value.Trim() } else { $_.BaseName })
+            }
+          }
+          Write-Host "Test assemblies (gated at ${testThreshold}%): $($testAssemblies -join ', ')"
+          Write-Host ""
 
           foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
             # Only consider top-level assembly rows: non-space first char,
@@ -1042,7 +1120,10 @@ jobs:
             # the gate on actually-100%-covered modules. Two changes:
             #  - Anchor on `^(\S+)` so indented sub-class rows are skipped
             #    (their parent assembly row carries the same number, so
-            #    nothing is lost — and Stage 1 ignores them too).
+            #    nothing is lost). Stage 1 skips them too, but ONLY because
+            #    its loop uses `IFS= read -r` — a bare `read -r` strips the
+            #    indentation and defeats its `^[^ ]` anchor. Keep both in
+            #    sync if either parser changes.
             #  - Require whitespace immediately before the final `\d+%`
             #    (`\s(\d+...)%\s*$`). This still allows intermediate
             #    columns between the module name and the final percent
@@ -1055,13 +1136,20 @@ jobs:
               $percent = [int][math]::Floor([double]$Matches[2])
               $matchedCount++
 
-              Write-Host "Checking module: '$module' - Coverage: ${percent}%"
+              # Gating the test ASSEMBLY row at 100% is equivalent to gating
+              # every one of its classes: an assembly only reaches 100% line
+              # coverage when every class in it is at 100%.
+              $isTest  = $testAssemblies -contains $module
+              $applies = if ($isTest) { $testThreshold } else { $threshold }
+              $kind    = if ($isTest) { "test" } else { "src" }
 
-              if ($percent -lt $threshold) {
-                Write-Host "  ❌ FAIL: Below ${threshold}% threshold" -ForegroundColor Red
-                $failedProjects += "$module (${percent}%)"
+              Write-Host "Checking $kind module: '$module' - Coverage: ${percent}%"
+
+              if ($percent -lt $applies) {
+                Write-Host "  ❌ FAIL: Below ${applies}% threshold" -ForegroundColor Red
+                $failedProjects += "$module (${percent}%, needs ${applies}%)"
               } else {
-                Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
+                Write-Host "  ✅ PASS: Meets ${applies}% threshold" -ForegroundColor Green
               }
             }
           }
@@ -1079,7 +1167,9 @@ jobs:
             Write-Host "==========================================" -ForegroundColor Red
             Write-Host "❌ COVERAGE GATE FAILED" -ForegroundColor Red
             Write-Host "==========================================" -ForegroundColor Red
-            Write-Host "Projects below ${threshold}% coverage: $($failedProjects -join ', ')" -ForegroundColor Red
+            Write-Host "Modules below their threshold: $($failedProjects -join ', ')" -ForegroundColor Red
+            Write-Host ""
+            Write-Host "src assemblies must reach ${threshold}%; test assemblies must reach ${testThreshold}%." -ForegroundColor Red
             Write-Host ""
             Write-Host "Stage 2 failed. macOS tests will NOT run."
             exit 1
@@ -1089,7 +1179,7 @@ jobs:
           Write-Host "==========================================" -ForegroundColor Green
           Write-Host "✅ COVERAGE GATE PASSED" -ForegroundColor Green
           Write-Host "==========================================" -ForegroundColor Green
-          Write-Host "All projects meet ${threshold}% coverage threshold."
+          Write-Host "src assemblies meet ${threshold}%; test assemblies meet ${testThreshold}%."
           Write-Host "Proceeding to Stage 3 (macOS tests)."
 
       - name: Upload Windows coverage results
@@ -1423,20 +1513,42 @@ jobs:
           echo ""
 
           THRESHOLD=${CODECOV_MINIMUM:-90}
+          TEST_THRESHOLD=${CODECOV_TEST_MINIMUM:-100}
           FAILED=0
           MATCHED=0
+
+          # Assembly names produced by projects under tests/ — see the matching
+          # Stage 1 block. Identify test assemblies by LOCATION, never by name:
+          # shipped product packages such as Wolfgang.Etl.TestKit live in src/
+          # and contain "Test".
+          TEST_ASSEMBLIES="|"
+          if [ -d ./tests ]; then
+            while IFS= read -r -d '' proj; do
+              asm=$(grep -oE '<AssemblyName>[^<]+' "$proj" 2>/dev/null | head -1 | cut -d'>' -f2)
+              if [ -z "$asm" ]; then
+                asm=$(basename "$proj"); asm="${asm%.*}"
+              fi
+              TEST_ASSEMBLIES="${TEST_ASSEMBLIES}${asm}|"
+            done < <(find ./tests -type f \( -name '*.csproj' -o -name '*.vbproj' -o -name '*.fsproj' \) -print0)
+          fi
+          echo "Test assemblies (gated at ${TEST_THRESHOLD}%): ${TEST_ASSEMBLIES}"
+          echo ""
 
           while IFS= read -r line; do
             if echo "$line" | grep -qE '^[^ ]+.*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
               MODULE=$(echo "$line" | awk '{print $1}')
               PERCENT=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | grep -oE '^[0-9]+')
               MATCHED=$((MATCHED + 1))
-              echo "Checking module: '$MODULE' - Coverage: ${PERCENT}%"
-              if [ "$PERCENT" -lt "$THRESHOLD" ]; then
-                echo "  ❌ FAIL: Below ${THRESHOLD}% threshold"
+              case "$TEST_ASSEMBLIES" in
+                *"|${MODULE}|"*) APPLIES=$TEST_THRESHOLD; KIND="test" ;;
+                *)               APPLIES=$THRESHOLD;      KIND="src"  ;;
+              esac
+              echo "Checking ${KIND} module: '$MODULE' - Coverage: ${PERCENT}%"
+              if [ "$PERCENT" -lt "$APPLIES" ]; then
+                echo "  ❌ FAIL: Below ${APPLIES}% threshold"
                 FAILED=1
               else
-                echo "  ✅ PASS: Meets ${THRESHOLD}% threshold"
+                echo "  ✅ PASS: Meets ${APPLIES}% threshold"
               fi
             fi
           done < CoverageReport/Summary.txt
@@ -1454,7 +1566,8 @@ jobs:
             echo "=========================================="
             echo "❌ COVERAGE GATE FAILED"
             echo "=========================================="
-            echo "One or more modules are below ${THRESHOLD}% coverage."
+            echo "One or more modules are below their threshold"
+            echo "(src ${THRESHOLD}%, test ${TEST_THRESHOLD}%)."
             echo "Stage 3 failed."
             exit 1
           fi
@@ -1463,7 +1576,7 @@ jobs:
           echo "=========================================="
           echo "✅ COVERAGE GATE PASSED"
           echo "=========================================="
-          echo "All modules meet ${THRESHOLD}% coverage threshold."
+          echo "src assemblies meet ${THRESHOLD}%; test assemblies meet ${TEST_THRESHOLD}%."
 
       - name: Upload macOS coverage results
         if: always()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # Minimum line coverage for PRODUCTION assemblies (anything under src/).
   CODECOV_MINIMUM: 90
+  # Minimum line coverage for TEST assemblies (anything under tests/).
+  # Kept in sync with pr.yaml — see the note there.
+  CODECOV_TEST_MINIMUM: 100
 
 jobs:
   # Streamlined validation: All frameworks, Windows only
@@ -296,24 +300,42 @@ jobs:
           
           # Parse coverage and enforce threshold per module (matching pr.yaml)
           $summaryContent = Get-Content CoverageReport/Summary.txt
-          $threshold = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
+          $threshold     = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
+          $testThreshold = if ($env:CODECOV_TEST_MINIMUM) { [int]$env:CODECOV_TEST_MINIMUM } else { 100 }
           $failedModules = @()
           $coverageFound = $false
-          
+
+          # Assembly names produced by projects under tests/ — mirrors pr.yaml.
+          # Identify test assemblies by LOCATION, never by name: shipped product
+          # packages such as Wolfgang.Etl.TestKit contain "Test" and live in src/.
+          $testAssemblies = @()
+          if (Test-Path "tests") {
+            Get-ChildItem -Path "tests" -Recurse -File -Include *.csproj,*.vbproj,*.fsproj | ForEach-Object {
+              $m = [regex]::Match((Get-Content $_.FullName -Raw), '<AssemblyName>([^<]+)</AssemblyName>')
+              $testAssemblies += $(if ($m.Success) { $m.Groups[1].Value.Trim() } else { $_.BaseName })
+            }
+          }
+
           foreach ($line in $summaryContent) {
-            # Match lines with module names and percentages (skip Summary line)
+            # Match lines with module names and percentages (skip Summary line).
+            # `^([^ ]+)` keeps indented per-class rows out — only assembly rows
+            # are gated, and an assembly only reaches 100% when every class does.
             if ($line -match '^([^ ]+)\s+.*\s+(\d+(?:\.\d+)?)%$' -and $line -notmatch '^Summary') {
               $coverageFound = $true
               $module = $matches[1]
               $coverage = [decimal]$matches[2]
-              
-              Write-Host "Checking module: '$module' - Coverage: ${coverage}%" -ForegroundColor Cyan
-              
-              if ($coverage -lt $threshold) {
-                Write-Host "  ❌ FAIL: Below ${threshold}% threshold" -ForegroundColor Red
-                $failedModules += "$module (${coverage}%)"
+
+              $isTest  = $testAssemblies -contains $module
+              $applies = if ($isTest) { $testThreshold } else { $threshold }
+              $kind    = if ($isTest) { "test" } else { "src" }
+
+              Write-Host "Checking $kind module: '$module' - Coverage: ${coverage}%" -ForegroundColor Cyan
+
+              if ($coverage -lt $applies) {
+                Write-Host "  ❌ FAIL: Below ${applies}% threshold" -ForegroundColor Red
+                $failedModules += "$module (${coverage}%, needs ${applies}%)"
               } else {
-                Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
+                Write-Host "  ✅ PASS: Meets ${applies}% threshold" -ForegroundColor Green
               }
             }
           }

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -22,7 +22,13 @@
     Skip DevSkim and gitleaks scans.
 
 .PARAMETER CoverageThreshold
-    Minimum coverage percentage required. Defaults to 90.
+    Minimum line coverage for PRODUCTION assemblies (anything under src/).
+    Defaults to 90. Mirrors CODECOV_MINIMUM in pr.yaml.
+
+.PARAMETER TestCoverageThreshold
+    Minimum line coverage for TEST assemblies (anything under tests/).
+    Defaults to 100 — test code that never executes has no purpose. Mirrors
+    CODECOV_TEST_MINIMUM in pr.yaml.
 
 .EXAMPLE
     pwsh ./scripts/build-pr.ps1
@@ -33,7 +39,8 @@ param(
     [switch]$SkipTests,
     [switch]$SkipCoverage,
     [switch]$SkipSecurity,
-    [int]$CoverageThreshold = 90
+    [int]$CoverageThreshold = 90,
+    [int]$TestCoverageThreshold = 100
 )
 
 $ErrorActionPreference = 'Stop'
@@ -162,7 +169,7 @@ if (-not $SkipTests -and $failed.Count -eq 0) {
 # STEP 3: Coverage Report and Threshold
 # ============================================================================
 if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
-    Write-Step "Step 3: Coverage Report (threshold: ${CoverageThreshold}%)"
+    Write-Step "Step 3: Coverage Report (src ${CoverageThreshold}%, tests ${TestCoverageThreshold}%)"
 
     $coverageFiles = Get-ChildItem -Path TestResults -Recurse -Filter coverage.cobertura.xml -ErrorAction SilentlyContinue
 
@@ -203,17 +210,36 @@ if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
             Get-Content "CoverageReport/Summary.txt"
             Write-Host ""
 
+            # Assembly names produced by projects under tests/ — mirrors pr.yaml.
+            # Identify test assemblies by LOCATION, never by name: shipped product
+            # packages such as Wolfgang.Etl.TestKit contain "Test" and live in src/.
+            $testAssemblies = @()
+            if (Test-Path "tests") {
+                Get-ChildItem -Path "tests" -Recurse -File -Include *.csproj,*.vbproj,*.fsproj | ForEach-Object {
+                    $m = [regex]::Match((Get-Content $_.FullName -Raw), '<AssemblyName>([^<]+)</AssemblyName>')
+                    $testAssemblies += $(if ($m.Success) { $m.Groups[1].Value.Trim() } else { $_.BaseName })
+                }
+            }
+
             $failedProjects = @()
             $matched = 0
             foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
-                if ($line -match '^\s*(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^\s*Summary') {
+                # Anchor on `^(\S+)` — NOT `^\s*(\S+)`. The leading `\s*` used to
+                # let ReportGenerator's indented per-class rows match, so individual
+                # classes were gated as if they were projects (the same defect
+                # pr.yaml's Stage 1 had via a bare `read -r`). Only assembly rows
+                # are gated; an assembly only reaches 100% when every class does.
+                if ($line -match '^(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
                     $module = $Matches[1]
                     $percent = [int][math]::Floor([double]$Matches[2])
                     $matched++
 
-                    if ($percent -lt $CoverageThreshold) {
-                        Write-Fail "  $module — ${percent}% (below ${CoverageThreshold}%)"
-                        $failedProjects += "$module (${percent}%)"
+                    $isTest    = $testAssemblies -contains $module
+                    $applies   = if ($isTest) { $TestCoverageThreshold } else { $CoverageThreshold }
+
+                    if ($percent -lt $applies) {
+                        Write-Fail "  $module — ${percent}% (below ${applies}%)"
+                        $failedProjects += "$module (${percent}%, needs ${applies}%)"
                     }
                     else {
                         Write-Pass "  $module — ${percent}%"


### PR DESCRIPTION
Closes #454. Canonical implementation of the fleet coverage-gate redesign — every downstream issue is blocked on this.

## What changes

**Two thresholds.** `CODECOV_MINIMUM` (90) now applies to production assemblies only. New `CODECOV_TEST_MINIMUM` (100) applies to test assemblies.

Rationale: test code that never executes has no purpose — an uncovered helper, fake, or branch in a test project is dead code and should be exercised or deleted. This is **line** coverage; branch coverage legitimately can't reach 100% (compiler-generated async state machines) and the gate never reads that column.

Gating the test **assembly** row at 100% is equivalent to gating every one of its classes — an assembly only reaches 100% line coverage when every class in it does — so the parser still only inspects assembly rows.

**Test assemblies are identified by location, never by name.** This is the trap worth knowing about: `Wolfgang.Etl.TestKit` and `Wolfgang.AuditTrail.TestKit.Xunit` are *shipped product packages* that contain "Test" and live in `src/`. Matching on the name would hold product code to the 100% rule. The set is built from project files under `tests/`, honouring `<AssemblyName>` where present, and delimited with `|` on both sides so membership can't match a prefix (`|Foo|` must not match `|FooBar|`).

**Two parser bugs fixed** — the same defect in two different disguises:

| file | bug |
|---|---|
| `pr.yaml` Stage 1 | bare `while read -r line` strips leading `IFS` whitespace, defeating its own `^[^ ]` anchor |
| `scripts/build-pr.ps1` | anchored `^\s*(\S+)` — the leading `\s*` lets indented rows match outright |

Both caused ReportGenerator's indented per-class rows to be gated as if they were projects. This is what failed ETL-SqlBulkCopy's 0.7.0 release on a test class at 89.4% while both real assemblies were above 97%.

Stage 2's comment asserted *"Stage 1 ignores them too"* — the false assumption that let the first variant survive. Corrected to name the `IFS=` requirement explicitly.

## Consistency

Stage 1, Stage 2, Stage 3, `release.yaml` and `build-pr.ps1` now apply one identical rule. They had drifted into three different parsers with three different behaviours; that drift is the root cause here.

## Verification

Replayed both code paths against the real `Summary.txt` artifact from ETL-SqlBulkCopy's failing run. Bash and pwsh agree exactly:

```
Wolfgang.Etl.SqlBulkCopy                   97%  src  gate=90%   PASS
Wolfgang.Etl.SqlBulkCopy.Tests.Unit        99%  test gate=100%  FAIL
  Classes below 100%:
    89.4%  ...BoundaryCoverageTests
    98.1%  ...ReflectionHelpersTests
    99%    ...ColumnMapTests
    99.4%  ...SqlBulkCopyLoaderTests
```

The failure names the short classes inline, so the fix is actionable without downloading the coverage artifact.

Second fixture confirms the naming trap is handled:

```
Wolfgang.Etl.TestKit              93%  -> src  gate=90%   PASS
Wolfgang.Etl.TestKit.Xunit        98%  -> src  gate=90%   PASS
Wolfgang.Etl.TestKit.Tests.Unit   99%  -> test gate=100%  FAIL
```

Both workflow files parse as valid YAML; `build-pr.ps1` parses clean under pwsh 7.

## Not in scope

`release.yaml` still runs `dotnet test` **without** `--settings coverlet.runsettings`, so it won't instrument test assemblies at all until that's fixed. Its gate is correct in advance of that change. Kept separate because it alters what release-time coverage measures and carries its own release risk — it's step 5 in the downstream issues.

## Merging

Touches `.github/workflows/*`, so `Detect .NET Projects` will fail by design and this needs a maintainer bypass merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
